### PR TITLE
[ITEP-25872] Fix App-Orch E2E test: caused due to the hidden toast

### DIFF
--- a/apps/app-orch/src/components/pages/EditDeployment/EditDeployment.tsx
+++ b/apps/app-orch/src/components/pages/EditDeployment/EditDeployment.tsx
@@ -420,6 +420,7 @@ const EditDeployment = () => {
         appVersion: deployment.appVersion,
         profileName: currentPackageProfile ? currentPackageProfile.name : "",
         displayName: currentDeploymentName,
+        deploymentType: deployment.deploymentType,
         targetClusters,
         overrideValues: overrideValues || [],
         publisherName: "intel", // FIXME remove once the API support it

--- a/apps/cluster-orch/deploy/Chart.yaml
+++ b/apps/cluster-orch/deploy/Chart.yaml
@@ -4,7 +4,7 @@ apiVersion: v2
 name: orch-ui-cluster-orch
 description: Deploy the Edge Orchestrator cluster-orch pod
 type: application
-version: 2.0.12
+version: 2.0.13-dev
 # Default appVersion will be overwritten by a the build to use the version from package.json.
 
 # This value is supplied only to enable local unbuilt deployment of released content.

--- a/apps/cluster-orch/src/components/organism/cluster/clusterCreation/ClusterNodesTableBySite/ClusterNodesTableBySite.tsx
+++ b/apps/cluster-orch/src/components/organism/cluster/clusterCreation/ClusterNodesTableBySite/ClusterNodesTableBySite.tsx
@@ -309,7 +309,7 @@ const ClusterNodesTableBySite = ({
             columns={columns}
             siteId={siteId}
             hasWorkload={false}
-            category="provisioned"
+            category="healthy"
             selectable
             selectedHosts={selectedHosts}
             poll={poll}

--- a/apps/infra/src/store/hostFilterBuilder.cy.ts
+++ b/apps/infra/src/store/hostFilterBuilder.cy.ts
@@ -20,6 +20,46 @@ const defaultSearchTerm: string = "searchTerm1";
 
 describe("When constructing the host filter builder", () => {
   let state: HostFilterBuilderState = {} as HostFilterBuilderState;
+
+  describe("the lifeCycleStateQuery should", () => {
+    it("contain a mapping for each lifecycle state", () => {
+      // Check that the map has entries for all lifecycle states
+      expect(lifeCycleStateQuery.size).to.equal(
+        Object.keys(LifeCycleState).length,
+      );
+
+      // Check if all enum values have corresponding query mappings
+      for (const state in LifeCycleState) {
+        if (isNaN(Number(state))) {
+          // Skip numeric keys from enum
+          expect(
+            lifeCycleStateQuery.has(
+              LifeCycleState[state as keyof typeof LifeCycleState],
+            ),
+          ).to.be.true;
+        }
+      }
+    });
+
+    it("return correct query strings for each lifecycle state", () => {
+      // Verify specific query strings for each lifecycle state
+      expect(lifeCycleStateQuery.get(LifeCycleState.Healthy)).to.include(
+        "instance.currentState=INSTANCE_STATE_RUNNING",
+      );
+      expect(lifeCycleStateQuery.get(LifeCycleState.Provisioned)).to.include(
+        "currentState=HOST_STATE_ONBOARDED AND has(instance)",
+      );
+      expect(lifeCycleStateQuery.get(LifeCycleState.Onboarded)).to.include(
+        "currentState=HOST_STATE_ONBOARDED AND NOT has(instance)",
+      );
+      expect(lifeCycleStateQuery.get(LifeCycleState.Registered)).to.include(
+        "currentState=HOST_STATE_REGISTERED OR currentState=HOST_STATE_UNSPECIFIED",
+      );
+
+      expect(lifeCycleStateQuery.get(LifeCycleState.All)).to.be.undefined;
+    });
+  });
+
   describe("the life cycle state should", () => {
     beforeEach(() => {
       state = {

--- a/apps/infra/src/store/hostFilterBuilder.ts
+++ b/apps/infra/src/store/hostFilterBuilder.ts
@@ -22,6 +22,7 @@ export enum LifeCycleState {
   Onboarded = "onboarded",
   Registered = "registered",
   All = "all",
+  Healthy = "healthy",
 }
 
 export enum AggregatedStatus {
@@ -43,6 +44,10 @@ const getIndicator = (
 ) => `STATUS_INDICATION_${value}` as eim.StatusIndicator;
 
 export const lifeCycleStateQuery = new Map<LifeCycleState, string | undefined>([
+  [
+    LifeCycleState.Healthy,
+    "(currentState=HOST_STATE_ONBOARDED AND has(instance) AND instance.currentState=INSTANCE_STATE_RUNNING)",
+  ],
   [
     LifeCycleState.Provisioned,
     "(currentState=HOST_STATE_ONBOARDED AND has(instance))",

--- a/tests/cypress/e2e/helpers/app-orch.ts
+++ b/tests/cypress/e2e/helpers/app-orch.ts
@@ -76,6 +76,5 @@ export function getDeploymentsMFETab() {
 
 /** get sidebar option by name */
 export function getSidebarTabByName(tabName: string) {
-  cy.waitForPageTransition();
   return cy.dataCy("sidebar").contains(tabName).should("be.visible");
 }


### PR DESCRIPTION
The E2E tests were seen failing due to a Hidden Toast component in Layout (right of the page).

Coincidentally, the button that was opening the registry drawer was getting covered by the hidden toast (requiring a force: true). This click was not working sometimes due to the toast. making the e2e test fail.

Fix
----
Making the toast code in Layout appear only when the `ToastState.visibility === ToastVisibility.show && (show component)`.
This could also prevent toast issue, when the screen size differs in cypress cli and gui.

<img width="493" alt="image" src="https://github.com/user-attachments/assets/2104a699-d4e9-4d37-8248-8d9b79e8cca8" />
