### PR TITLE
[ITEP-26559] Use HostId instead of UUID in metrics link for Hosts

### DIFF
--- a/apps/infra/src/components/molecules/ProvisionedHostPopup/ProvisionedHostPopup.tsx
+++ b/apps/infra/src/components/molecules/ProvisionedHostPopup/ProvisionedHostPopup.tsx
@@ -106,8 +106,8 @@ const ProvisionedHostPopup = (props: ProvisionedHostPopupProps) => {
     provisionedHostPopup.push({
       displayText: "View Metrics",
       onSelect() {
-        const url = `${getObservabilityUrl()}/d/edgenode_host/edge-node?orgId=1&refresh=30s&var-guid=${
-          host.uuid
+        const url = `${getObservabilityUrl()}/d/edgenode_host/edge-node?orgId=1&refresh=30s&var-hostId=${
+          host.resourceId
         }&var-projectId=${project.uID}&var-projectName=${project.name}`;
         window.open(url, "_newtab");
       },


### PR DESCRIPTION
Tested in coder:

https://github.com/user-attachments/assets/0f757b8b-b4ac-49ab-aaf9-7bc5908d2a4e

