### PR TITLE
Display lifecyclePhase instead of providerStatus in Cluster List

### DIFF
--- a/apps/cluster-orch/src/components/organism/ClusterList/ClusterList.tsx
+++ b/apps/cluster-orch/src/components/organism/ClusterList/ClusterList.tsx
@@ -67,7 +67,7 @@ const ClusterList = ({
       Cell: (table) => (
         <AggregatedStatuses<AggregatedStatusesMap>
           statuses={clusterToStatuses(table.row.original)}
-          defaultStatusName="providerStatus"
+          defaultStatusName="lifecyclePhase"
         />
       ),
     },

--- a/apps/cluster-orch/src/components/organism/cluster/ClusterList.cy.tsx
+++ b/apps/cluster-orch/src/components/organism/cluster/ClusterList.cy.tsx
@@ -56,7 +56,7 @@ describe("<ClusterList />", () => {
         // Check Status
         const statusMessage = aggregateStatuses<ClusterGenericStatuses>(
           clusterToStatuses(c),
-          "providerStatus",
+          "lifecyclePhase",
         ).message;
         pom.root.contains(statusMessage);
       });

--- a/apps/cluster-orch/src/components/organism/cluster/ClusterList.tsx
+++ b/apps/cluster-orch/src/components/organism/cluster/ClusterList.tsx
@@ -230,7 +230,7 @@ export default function ClusterList({ hasPermission }: ClusterListProps) {
         return (
           <AggregatedStatuses<AggregatedStatusesMap>
             statuses={clusterToStatuses(table.row.original)}
-            defaultStatusName="providerStatus"
+            defaultStatusName="lifecyclePhase"
           />
         );
       },

--- a/apps/cluster-orch/src/components/pages/ClusterDetail/ClusterDetail.cy.tsx
+++ b/apps/cluster-orch/src/components/pages/ClusterDetail/ClusterDetail.cy.tsx
@@ -58,7 +58,7 @@ describe("<ClusterDetail />", () => {
         "contain.text",
         aggregateStatuses<ClusterGenericStatuses>(
           clusterToStatuses(pom.testCluster),
-          "providerStatus",
+          "lifecyclePhase",
         ).message,
       );
     });

--- a/apps/cluster-orch/src/components/pages/ClusterDetail/ClusterDetail.tsx
+++ b/apps/cluster-orch/src/components/pages/ClusterDetail/ClusterDetail.tsx
@@ -409,7 +409,7 @@ function ClusterDetail({
         <div data-cy={`${dataCy}Status`}>
           <AggregatedStatuses<AggregatedStatusesMap>
             statuses={clusterToStatuses(clusterDetail)}
-            defaultStatusName="providerStatus"
+            defaultStatusName="lifecyclePhase"
           />
         </div>
       </header>


### PR DESCRIPTION
Required to fix a regression introduced in #21 