### PR TITLE
remove run_security_scans param

### DIFF
--- a/.github/workflows/post-merge-admin.yml
+++ b/.github/workflows/post-merge-admin.yml
@@ -18,7 +18,6 @@ jobs:
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@main
     with:
       bootstrap_tools: "base,helm,yq,jq"
-      run_security_scans: true
       run_version_check: true
       run_dep_version_check: false
       run_build: false

--- a/.github/workflows/post-merge-app-orch.yml
+++ b/.github/workflows/post-merge-app-orch.yml
@@ -18,7 +18,6 @@ jobs:
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@main
     with:
       bootstrap_tools: "base,helm,yq,jq"
-      run_security_scans: true
       run_version_check: true
       run_dep_version_check: false
       run_build: false

--- a/.github/workflows/post-merge-cluster-orch.yml
+++ b/.github/workflows/post-merge-cluster-orch.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   post-merge-pipeline:
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@feature/push-dev-images
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@main
     with:
       bootstrap_tools: "base,helm,yq,jq"
       run_version_check: true

--- a/.github/workflows/post-merge-cluster-orch.yml
+++ b/.github/workflows/post-merge-cluster-orch.yml
@@ -18,7 +18,6 @@ jobs:
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@main
     with:
       bootstrap_tools: "base,helm,yq,jq"
-      run_security_scans: true
       run_version_check: true
       run_dep_version_check: false
       run_build: false

--- a/.github/workflows/post-merge-cluster-orch.yml
+++ b/.github/workflows/post-merge-cluster-orch.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   post-merge-pipeline:
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@main
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@feature/push-dev-images
     with:
       bootstrap_tools: "base,helm,yq,jq"
       run_version_check: true

--- a/.github/workflows/post-merge-infra.yml
+++ b/.github/workflows/post-merge-infra.yml
@@ -18,7 +18,6 @@ jobs:
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@main
     with:
       bootstrap_tools: "base,helm,yq,jq"
-      run_security_scans: true
       run_version_check: true
       run_dep_version_check: false
       run_build: false

--- a/.github/workflows/post-merge-root.yml
+++ b/.github/workflows/post-merge-root.yml
@@ -18,7 +18,6 @@ jobs:
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@main
     with:
       bootstrap_tools: "base,helm,yq,jq"
-      run_security_scans: true
       run_version_check: true
       run_dep_version_check: false
       run_build: false

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -18,7 +18,6 @@ jobs:
     uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@main
     with:
       bootstrap_tools: "base,helm,yq,jq"
-      run_security_scans: true
       run_version_check: true
       run_dep_version_check: false
       run_build: false

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -87,7 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         project_folder: ${{ (needs.setup-conditions.outputs.common_condition == 'true' && fromJson('["admin", "app-orch", "cluster-orch", "infra", "root"]')) || fromJson(needs.detect-changed-folders.outputs.changed_apps) }}
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@main
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@feature/push-dev-images
     with:
       bootstrap_tools: "base,helm,yq,jq"
       run_security_scans: true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -87,7 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         project_folder: ${{ (needs.setup-conditions.outputs.common_condition == 'true' && fromJson('["admin", "app-orch", "cluster-orch", "infra", "root"]')) || fromJson(needs.detect-changed-folders.outputs.changed_apps) }}
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@feature/push-dev-images
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@main
     with:
       bootstrap_tools: "base,helm,yq,jq"
       run_security_scans: true


### PR DESCRIPTION
# PR Description

The `run_security_scans` param is not supported by the post-merge workflow anymore. Removing it to fix broken CI.

## Changes

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated