### PR TITLE
Restoring static public-path to support local dev server

### DIFF
--- a/apps/admin/config/webpack.dev.js
+++ b/apps/admin/config/webpack.dev.js
@@ -28,7 +28,7 @@ const devConfig = {
     plugins: [new TsconfigPathsPlugin({ configFile: "tsconfig.dev.json" })],
   },
   output: {
-    publicPath: "auto",
+    publicPath: "http://localhost:8084/",
   },
   devServer: {
     port: 8084,

--- a/apps/app-orch/config/webpack.dev.js
+++ b/apps/app-orch/config/webpack.dev.js
@@ -17,7 +17,7 @@ const devConfig = {
     plugins: [new TsconfigPathsPlugin({ configFile: "tsconfig.dev.json" })],
   },
   output: {
-    publicPath: "auto",
+    publicPath: "http://localhost:8081/",
   },
   devServer: {
     port: 8081,

--- a/apps/cluster-orch/config/webpack.dev.js
+++ b/apps/cluster-orch/config/webpack.dev.js
@@ -18,7 +18,7 @@ const devConfig = {
     plugins: [new TsconfigPathsPlugin({ configFile: "tsconfig.dev.json" })],
   },
   output: {
-    publicPath: "auto",
+    publicPath: "http://localhost:8083/",
   },
   devServer: {
     port: 8083,

--- a/apps/infra/config/webpack.dev.js
+++ b/apps/infra/config/webpack.dev.js
@@ -31,7 +31,7 @@ const devConfig = {
     plugins: [new TsconfigPathsPlugin({ configFile: "tsconfig.dev.json" })],
   },
   output: {
-    publicPath: "auto",
+    publicPath: "http://localhost:8082/",
   },
   devServer: {
     open: false,

--- a/apps/root/config/webpack.dev.js
+++ b/apps/root/config/webpack.dev.js
@@ -29,7 +29,7 @@ const devConfig = {
     plugins: [new TsconfigPathsPlugin({ configFile: "tsconfig.dev.json" })],
   },
   output: {
-    publicPath: "auto",
+    publicPath: "http://localhost:8080/",
   },
   devServer: {
     port: 8080,


### PR DESCRIPTION
# PR Description

Restores functionality in the local del server by reverting the change to `publicPath: auto`

## Checklist

- [ ] Tests passed
- [ ] Documentation updated