### PR TITLE
Change orderBy status in clusterList

### DIFF
--- a/apps/cluster-orch/src/components/organism/ClusterList/ClusterList.tsx
+++ b/apps/cluster-orch/src/components/organism/ClusterList/ClusterList.tsx
@@ -63,7 +63,7 @@ const ClusterList = ({
           clusterToStatuses(item as cm.ClusterInfoRead),
           "lifecyclePhase",
         ).message,
-      apiName: "status",
+      apiName: "providerStatus",
       Cell: (table) => (
         <AggregatedStatuses<AggregatedStatusesMap>
           statuses={clusterToStatuses(table.row.original)}

--- a/apps/cluster-orch/src/components/organism/cluster/ClusterList.tsx
+++ b/apps/cluster-orch/src/components/organism/cluster/ClusterList.tsx
@@ -240,7 +240,7 @@ export default function ClusterList({ hasPermission }: ClusterListProps) {
       Header: "Cluster Status",
       accessor: (item) =>
         aggregateStatuses(clusterToStatuses(item), "lifecyclePhase").message,
-      apiName: "status",
+      apiName: "providerStatus",
       Cell: (table) => {
         return (
           <AggregatedStatuses<AggregatedStatusesMap>


### PR DESCRIPTION
# PR Description

Changed orderBy 'status' to 'providerStatus' in clusterList files, as the API call requires changing that field.

## Additional Information

The tests are still passing.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated