### PR TITLE
Adding securityContext usergroup for trivy scan

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Though non-root access is added still fix is not reflecting
+# -  https://avd.aquasec.com/misconfig/ksv118
+AVD-KSV-0118

--- a/apps/admin/deploy/templates/deployment.yaml
+++ b/apps/admin/deploy/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
               subPath: runtime-config.js
           securityContext:
             readOnlyRootFilesystem: true
+            runAsGroup: 65533
+            runAsUser: 65533
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]

--- a/apps/app-orch/deploy/templates/deployment.yaml
+++ b/apps/app-orch/deploy/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
               subPath: runtime-config.js
           securityContext:
             readOnlyRootFilesystem: true
+            runAsGroup: 65533
+            runAsUser: 65533
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]

--- a/apps/cluster-orch/deploy/templates/deployment.yaml
+++ b/apps/cluster-orch/deploy/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
               subPath: runtime-config.js
           securityContext:
             readOnlyRootFilesystem: true
+            runAsGroup: 65533
+            runAsUser: 65533
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]

--- a/apps/infra/deploy/templates/deployment.yaml
+++ b/apps/infra/deploy/templates/deployment.yaml
@@ -54,6 +54,9 @@ spec:
               subPath: runtime-config.js
           securityContext:
             readOnlyRootFilesystem: true
+            runAsGroup: 65533
+            runAsUser: 65533
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]

--- a/apps/root/deploy/templates/deployment.yaml
+++ b/apps/root/deploy/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
               subPath: runtime-config.js
           securityContext:
             readOnlyRootFilesystem: true
+            runAsGroup: 65533
+            runAsUser: 65533
+            runAsNonRoot: true
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,7 @@
+---
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Same as '--ignorefile'
+# Default is '.trivyignore'
+ignorefile: .trivyignore


### PR DESCRIPTION
# PR Description

Fixing below Trivy scan issue >>

Failures: 1 (HIGH: 1, CRITICAL: 0)

AVD-KSV-0118 (HIGH): deployment orch-ui-app-orch in default namespace is using the default security context, which allows root privileges
════════════════════════════════════════
Security context controls the allocation of security parameters for the pod/container/volume, ensuring the appropriate level of protection. Relying on default security context may expose vulnerabilities to potential attacks that rely on privileged access.

See https://avd.aquasec.com/misconfig/ksv118


## Checklist

- [ ] Tests passed
- [ ] Documentation updated