### PR TITLE
[ITEP-21955] CSP Headers for XSS

### DIFF
--- a/apps/admin/config/webpack.prod.js
+++ b/apps/admin/config/webpack.prod.js
@@ -43,7 +43,7 @@ const prodConfig = {
   plugins: [
     new ModuleFederationPlugin({
       remotes: {
-        AppOrchUI: `AppOrchUI@http://localhost:8081/remoteEntry.js`,
+        AppOrchUI: `AppOrchUI@h/mfe/appplications/remoteEntry.js`,
         ClusterOrchUI: `ClusterOrchUI@/mfe/cluster-orch/remoteEntry.js`,
         EimUI: `EimUI@/mfe/infrastructure/remoteEntry.js`,
       },

--- a/apps/root/config/webpack.common.js
+++ b/apps/root/config/webpack.common.js
@@ -9,7 +9,10 @@ const DefinePlugin = require("webpack/lib/DefinePlugin");
 const CopyPlugin = require("copy-webpack-plugin");
 const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
-const webpackUtils = require("../../../library/utils/webpack.util");
+const {
+  getClientEnvironment,
+  NoncePlaceholder,
+} = require("../../../library/utils/webpack.util");
 const { dependencies, version } = require("../../../package.json");
 const path = require("path");
 
@@ -95,10 +98,11 @@ module.exports = {
         },
       },
     }),
-    new DefinePlugin(webpackUtils.getClientEnvironment().stringified),
+    new DefinePlugin(getClientEnvironment().stringified),
     new HtmlWebpackPlugin({
       template: "./public/index.html",
     }),
+    new NoncePlaceholder(),
     new CopyPlugin({
       patterns: [{ from: "./public/runtime-config.js", to: "." }],
     }),

--- a/apps/root/config/webpack.common.js
+++ b/apps/root/config/webpack.common.js
@@ -26,11 +26,6 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.(ts|tsx)$/,
-        exclude: [/node_modules/, /\.cy\.tsx$/, /\.pom\.ts/],
-        use: ["@jsdevtools/coverage-istanbul-loader", "ts-loader"],
-      },
-      {
         test: /\.(s[ac]ss|css)$/i,
         use: [
           // Creates `style` nodes from JS strings

--- a/apps/root/config/webpack.dev.js
+++ b/apps/root/config/webpack.dev.js
@@ -16,6 +16,11 @@ const devConfig = {
   module: {
     rules: [
       {
+        test: /\.(ts|tsx)$/,
+        exclude: [/node_modules/, /\.cy\.tsx$/, /\.pom\.ts/],
+        use: ["@jsdevtools/coverage-istanbul-loader", "ts-loader"],
+      },
+      {
         test: /.*\.pom.(ts|tsx)?$/,
         use: [{ loader: "ignore-loader" }],
       },

--- a/apps/root/config/webpack.dev.js
+++ b/apps/root/config/webpack.dev.js
@@ -42,6 +42,12 @@ const devConfig = {
       "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
       "Access-Control-Allow-Headers":
         "X-Requested-With, content-type, Authorization",
+      // "Content-Security-Policy": [
+      //   "default-src 'self';",
+      //   "script-src 'nonce-UNIQUE_NONCE' 'strict-dynamic'",
+      //   "'unsafe-eval'",
+      //   "https:; object-src 'none'; base-uri 'self';",
+      // ].join(" "),
     },
     onListening: function (devServer) {
       if (!devServer) {

--- a/apps/root/config/webpack.prod.js
+++ b/apps/root/config/webpack.prod.js
@@ -13,6 +13,11 @@ const prodConfig = {
   module: {
     rules: [
       {
+        test: /\.(ts|tsx)$/,
+        exclude: [/node_modules/, /\.cy\.tsx$/, /\.pom\.ts/],
+        use: ["ts-loader"],
+      },
+      {
         test: /.*\.pom.tsx?$/,
         use: [{ loader: "ignore-loader" }],
       },

--- a/apps/root/deploy/templates/_helpers.tpl
+++ b/apps/root/deploy/templates/_helpers.tpl
@@ -29,7 +29,13 @@ Create chart name and version as used by the chart label.
 {{ $root := . }}
 server {
   listen 3000;
-  add_header Content-Security-Policy "script-src 'nonce-$request_id' 'strict-dynamic' 'unsafe-inline' https:; object-src 'none'; base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline'";
+  set $SCRIPT "script-src 'nonce-$request_id' 'strict-dynamic' 'unsafe-inline' https:;";
+  set $OBJECT "object-src 'none';";
+  set $DEFAULT "default-src 'self';";
+  set $STYLE "style-src 'self' 'unsafe-inline';";
+  set $CONNECT "connect-src 'self';";
+  set $VARIOUS "frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; base-uri 'self';";
+  add_header Content-Security-Policy "${SCRIPT} ${OBJECT} ${DEFAULT} ${CONNECT} ${STYLE} ${VARIOUS}";
   add_header X-Frame-Options "DENY";
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
   add_header X-XSS-Protection "1; mode=block";

--- a/apps/root/deploy/templates/_helpers.tpl
+++ b/apps/root/deploy/templates/_helpers.tpl
@@ -29,7 +29,7 @@ Create chart name and version as used by the chart label.
 {{ $root := . }}
 server {
   listen 3000;
-  add_header Content-Security-Policy "frame-ancestors 'self' ";
+  add_header Content-Security-Policy "script-src 'nonce-$request_id' 'strict-dynamic' 'unsafe-inline' https:; object-src 'none'; base-uri 'self'; default-src 'self';";
   add_header X-Frame-Options "DENY";
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
   add_header X-XSS-Protection "1; mode=block";
@@ -52,6 +52,8 @@ server {
   location / {
     limit_except GET { deny  all; }
     root   /usr/share/nginx/html;
+    sub_filter_once off;
+    sub_filter 'UNIQUE_NONCE' $request_id;
     index  index.html index.htm;
     try_files $uri $uri/ /index.html;
   }

--- a/apps/root/deploy/templates/_helpers.tpl
+++ b/apps/root/deploy/templates/_helpers.tpl
@@ -29,7 +29,7 @@ Create chart name and version as used by the chart label.
 {{ $root := . }}
 server {
   listen 3000;
-  add_header Content-Security-Policy "script-src 'nonce-$request_id' 'strict-dynamic' 'unsafe-inline' https:; object-src 'none'; base-uri 'self'; default-src 'self';";
+  add_header Content-Security-Policy "script-src 'nonce-$request_id' 'strict-dynamic' 'unsafe-inline' https:; object-src 'none'; base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline'";
   add_header X-Frame-Options "DENY";
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
   add_header X-XSS-Protection "1; mode=block";

--- a/apps/root/deploy/templates/deployment.yaml
+++ b/apps/root/deploy/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
             - name: runtime-config
               mountPath: /usr/share/nginx/html/runtime-config.js
               subPath: runtime-config.js
+            - mountPath: /tmp
+              name: tmp
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
@@ -73,4 +75,6 @@ spec:
             items:
               - key: config
                 path: runtime-config.js
+        - emptyDir: {}
+          name: tmp
 

--- a/apps/root/deploy/templates/ingress-route.yaml
+++ b/apps/root/deploy/templates/ingress-route.yaml
@@ -15,7 +15,7 @@ spec:
     - match: ({{ required "A valid hostname entry required!" .Values.service.traefik.hostname }} || {{ required "A valid baseHostname entry required!" .Values.service.traefik.baseHostname }}) && PathPrefix(`/`)
       kind: Rule
       middlewares:
-        # - name: secure-headers
+        - name: secure-headers
         - name: {{ include "root.fullname" . }}
       priority: 10
       services:

--- a/apps/root/deploy/templates/ingress-route.yaml
+++ b/apps/root/deploy/templates/ingress-route.yaml
@@ -15,7 +15,7 @@ spec:
     - match: ({{ required "A valid hostname entry required!" .Values.service.traefik.hostname }} || {{ required "A valid baseHostname entry required!" .Values.service.traefik.baseHostname }}) && PathPrefix(`/`)
       kind: Rule
       middlewares:
-        - name: secure-headers
+        # - name: secure-headers
         - name: {{ include "root.fullname" . }}
       priority: 10
       services:

--- a/apps/root/index.d.ts
+++ b/apps/root/index.d.ts
@@ -17,6 +17,7 @@ declare global {
   interface Window {
     __RUNTIME_CONFIG__: RuntimeConfig;
     Cypress: { testingType: string };
+    nonce?: string;
   }
   namespace Cypress {
     interface Chainable {
@@ -29,4 +30,5 @@ declare global {
   let __webpack_public_path__: string;
   let __webpack_base_uri__: string;
   let __webpack_share_scopes__: any;
+  let __webpack_nonce__: string | undefined;
 }

--- a/apps/root/public/index.html
+++ b/apps/root/public/index.html
@@ -3,16 +3,23 @@
 
 <!DOCTYPE html>
 <html lang="en" data-theme-colors="tb">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" href="assets/favicon.png" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Edge Orchestrator</title>
-    <!-- Runtime environment variables -->
-    <script src="/runtime-config.js"></script>
-  </head>
-  <body>
-    <div id="root"></div>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" href="assets/favicon.png" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Edge Orchestrator</title>
+  <!-- Storying generated NONCE so we can add it to every script -->
+  <script nonce="UNIQUE_NONCE">
+    window.nonce = "UNIQUE_NONCE";
+  </script>
+  <!-- Runtime environment variables -->
+  <script nonce="UNIQUE_NONCE" src="/runtime-config.js"></script>
+</head>
+
+<body>
+  <div id="root"></div>
+</body>
+
 </html>

--- a/apps/root/src/index.tsx
+++ b/apps/root/src/index.tsx
@@ -2,5 +2,6 @@
  * SPDX-FileCopyrightText: (C) 2023 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
+__webpack_nonce__ = window.nonce
 
 import("./bootstrap");

--- a/library/utils/webpack.util.js
+++ b/library/utils/webpack.util.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
 const REGEX = /^REACT_/i;
 function getClientEnvironment() {
   const raw = Object.keys(process.env)
@@ -24,6 +26,24 @@ function getClientEnvironment() {
   return { raw, stringified };
 }
 
+class NoncePlaceholder {
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap("NoncePlaceholder", (compilation) => {
+      HtmlWebpackPlugin.getHooks(compilation).afterTemplateExecution.tapAsync(
+        "NoncePlaceholder",
+        (data, cb) => {
+          const { headTags } = data;
+          headTags.forEach((x) => {
+            x.attributes.nonce = "UNIQUE_NONCE";
+          });
+          cb(null, data);
+        },
+      );
+    });
+  }
+}
+
 module.exports = {
   getClientEnvironment,
+  NoncePlaceholder,
 };


### PR DESCRIPTION
# PR Description

Making all required changes to reduce XSS attack surface.

## Changes

Added `script-src 'strict-dynamic'` with unique `nonce` per request: https://content-security-policy.com/strict-dynamic/

Requires to remove this [line](https://github.com/open-edge-platform/orch-utils/blob/main/charts/traefik-extra-objects/templates/traefik-extra-objects.yaml#L334) (will open a PR) but it still failing as spark-island requires `unsafe-eval` to be enabled because of https://github.com/open-edge-platform/orch-ui/blob/main/library/%40spark-design/core/lib/esm/custom-property.js#L5 (I don't have a solution for this yet)

## Checklist

- [x] Tests passed
- [x] Documentation updated