### PR TITLE
Itep 68661 continuation

### DIFF
--- a/apps/infra/src/store/notifications.ts
+++ b/apps/infra/src/store/notifications.ts
@@ -24,7 +24,7 @@ export interface MessageBannerState {
 export interface _MessageBannerState
   extends Omit<MessageBannerProps, "onClose" | "className"> {}
 
-interface NotificationsState {
+export interface NotificationsState {
   messageBanner?: _MessageBannerState;
   messageBannerDuration?: number;
   messageState: MessageBannerState;

--- a/apps/infra/src/store/store.ts
+++ b/apps/infra/src/store/store.ts
@@ -13,7 +13,6 @@ import {
 } from "@reduxjs/toolkit";
 import { setupListeners } from "@reduxjs/toolkit/query";
 import configureHostReducer from "./configureHost";
-import hostFilterBuilderReducer from "./hostFilterBuilder";
 import hostStatusReducer from "./hostStatus";
 import locationsReducer from "./locations";
 import notificationStatusReducer from "./notifications";
@@ -23,7 +22,6 @@ const rootReducer = combineReducers({
   hostStatusList: hostStatusReducer,
   configureHost: configureHostReducer,
   locations: locationsReducer,
-  hostFilterBuilder: hostFilterBuilderReducer,
   [enhancedEimSlice.miEnhancedApi.reducerPath]:
     enhancedEimSlice.miEnhancedApi.reducer,
   [mbApi.metadataBroker.reducerPath]: mbApi.metadataBroker.reducer,


### PR DESCRIPTION
# PR Description

ITEP 68661 continuation

## Changes

- Removed Redux state management from _hostFilterBuilder.ts_
- Refactored the _buildFilter_ function into a new function _buildFilterNew_, which now accepts required parameters explicitly. This allows us to generate filters by directly calling _buildFilterNew(...)_ with the necessary inputs.
- Updated the filtering logic to ensure that the UUID column takes precedence over _uuidsQuery_, and similarly for _resourceId_.

## Additional Information



## Checklist

- [ ] Tests passed
- [ ] Documentation updated