### PR TITLE
Display host readiness and OS details in cluster edit view

### DIFF
--- a/apps/cluster-orch/src/components/atom/ClusterEditNodeReview/ClusterEditNodeReview.cy.tsx
+++ b/apps/cluster-orch/src/components/atom/ClusterEditNodeReview/ClusterEditNodeReview.cy.tsx
@@ -25,6 +25,34 @@ describe("<ClusterEditNodeReview/>", () => {
     });
   });
 
+  describe("when node/host are available", () => {
+    beforeEach(() => {
+      pom.interceptApis([pom.api.getHost]);
+      cy.mount(
+        <ClusterEditNodeReview
+          clusterNodeList={[
+            {
+              id: "host-provisioned-1",
+              role: "all",
+              status: {
+                condition: "STATUS_CONDITION_READY",
+                reason: "Running",
+              },
+            },
+          ]}
+          onNodeUpdate={cy.stub()}
+        />,
+      );
+    });
+    it("should render component with host details", () => {
+      pom.root.should("exist");
+      pom.waitForApis();
+      pom.table.getCell(1, 1).contains("host-provisioned-1"); // host name fetched from host api response
+      pom.table.getCell(1, 2).contains("Running"); // from node status
+      pom.table.getCell(1, 3).contains("Ubuntu"); // os name etched from host api response
+    });
+  });
+
   describe("when nodes/hosts are available", () => {
     beforeEach(() => {
       cy.mount(
@@ -32,36 +60,25 @@ describe("<ClusterEditNodeReview/>", () => {
           clusterNodeList={[
             {
               id: "host-unassign1",
-              os: "Ubuntu",
-              name: "host-unassign1",
               role: "all",
             },
             {
               id: "host-unassign2",
-              os: "Ubuntu",
-              name: "host-unassign2",
               role: "controlplane",
             },
             {
               id: "host-unassign3",
-              os: "Ubuntu",
-              name: "host-unassign3",
               role: "worker",
             },
             {
               id: "host-unassign4",
-              os: "Ubuntu",
-              name: "host-unassign4",
               role: "",
             },
             {
               id: "host-noname",
-              os: "Ubuntu",
             },
             {
               id: "host-unknown",
-              os: "Ubuntu",
-              name: "host-unknown",
               role: "unknown",
             },
           ]}
@@ -108,8 +125,6 @@ describe("<ClusterEditNodeReview/>", () => {
         "be.calledWith",
         {
           id: "host-unknown",
-          os: "Ubuntu",
-          name: "host-unknown",
           role: "unknown",
         },
         "worker",

--- a/apps/cluster-orch/src/components/atom/ClusterEditNodeReview/ClusterEditNodeReview.pom.ts
+++ b/apps/cluster-orch/src/components/atom/ClusterEditNodeReview/ClusterEditNodeReview.pom.ts
@@ -3,16 +3,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { infra } from "@orch-ui/apis";
 import { SiTablePom } from "@orch-ui/poms";
-import { CyPom } from "@orch-ui/tests";
+import { CyApiDetails, CyPom, defaultActiveProject } from "@orch-ui/tests";
+import { provisionedHostOne } from "@orch-ui/utils";
 
 const dataCySelectors = ["addHostBtn"] as const;
 type Selectors = (typeof dataCySelectors)[number];
 
-class ClusterEditNodeReviewPom extends CyPom<Selectors> {
+type ApiAliases = "getHost";
+
+const hostRoute = `**/projects/${defaultActiveProject.name}/compute/hosts**`;
+const endpoints: CyApiDetails<
+  ApiAliases,
+  infra.HostServiceListHostsApiResponse
+> = {
+  getHost: {
+    route: hostRoute,
+    statusCode: 200,
+    response: {
+      hosts: [provisionedHostOne],
+      hasNext: false,
+      totalElements: 1,
+    },
+  },
+};
+
+class ClusterEditNodeReviewPom extends CyPom<Selectors, ApiAliases> {
   table: SiTablePom;
   constructor(public rootCy: string = "clusterEditNodeReview") {
-    super(rootCy, [...dataCySelectors]);
+    super(rootCy, [...dataCySelectors], endpoints);
     this.table = new SiTablePom("reviewTable");
   }
 

--- a/apps/cluster-orch/src/components/atom/ClusterEditNodeReview/ClusterEditNodeReview.tsx
+++ b/apps/cluster-orch/src/components/atom/ClusterEditNodeReview/ClusterEditNodeReview.tsx
@@ -51,34 +51,19 @@ const ClusterEditNodeReview = ({
     },
   );
 
-  const data: CombinedNodeHostItem[] = useMemo(() => {
+  const combinedNodeHostsList: CombinedNodeHostItem[] = useMemo(() => {
     if (clusterNodeList?.length === 0) {
       return [];
     }
+
     return clusterNodeList.map((node) => {
       const host = hostsResponse?.hosts?.find(
         (host) => host.resourceId === node.id,
       );
       return host ? { ...host, ...node } : node;
     });
-  }, [clusterNodeList]);
-  // const data: CombinedNodeHostList = [];
+  }, [clusterNodeList, hostsResponse?.hosts]);
 
-  // if (nodesCount > 0) {
-  //   clusterNodeList?.forEach((node) => {
-  //     const host = hostsResponse?.hosts?.find(
-  //       (host) => host.resourceId === node.id,
-  //     );
-  //     if (host) {
-  //       data.push({
-  //         ...host,
-  //         status: node.status,
-  //         role: node.role,
-  //       });
-  //     }
-  //   });
-  // }
-  //================
   // these columns define the nodes in the cluster.
   // They are used to render information about the node
   const columns: TableColumn<CombinedNodeHostItem>[] = [
@@ -121,7 +106,7 @@ const ClusterEditNodeReview = ({
         Hosts
       </Heading>
 
-      {data.length > 0 ? (
+      {combinedNodeHostsList.length > 0 ? (
         // TODO: replace this with ClusterNodesTable with a @orch-ui/components
         // NOTE: ClusterNodesTable doesn't work with affect by addition of row
         //       within same page.
@@ -129,7 +114,7 @@ const ClusterEditNodeReview = ({
           <Table
             variant="minimal"
             columns={columns}
-            data={data}
+            data={combinedNodeHostsList}
             sort={[0, 1, 2, 3]}
             initialSort={{
               column: "Host Name",

--- a/apps/cluster-orch/src/components/organism/ClusterEdit/HostSelection/HostSelection.cy.tsx
+++ b/apps/cluster-orch/src/components/organism/ClusterEdit/HostSelection/HostSelection.cy.tsx
@@ -20,7 +20,7 @@ const HostTableRemoteMock = ({
 }: {
   columns: TableColumn<infra.HostResourceRead>[];
   selectedHostIds?: string[];
-  onHostSelect: (host: infra.Host, isSelected: boolean) => void;
+  onHostSelect: (host: infra.HostResource, isSelected: boolean) => void;
 }) => {
   return (
     <Table
@@ -73,7 +73,6 @@ describe("<HostSelection/>", () => {
             nodes: [
               {
                 id: "host-dh38bjw9",
-                name: "host-dh38bjw9",
                 status: {
                   condition: "STATUS_CONDITION_READY",
                 },
@@ -93,7 +92,6 @@ describe("<HostSelection/>", () => {
                     nodes: [
                       {
                         id: "host-dh38bjw9",
-                        name: "host-dh38bjw9",
                         status: {
                           condition: "STATUS_CONDITION_READY",
                         },
@@ -204,7 +202,6 @@ describe("<HostSelection/>", () => {
           nodes: [
             {
               id: "host-dh38bjw9",
-              name: "host-dh38bjw9",
               status: {
                 condition: "STATUS_CONDITION_READY",
               },
@@ -214,7 +211,6 @@ describe("<HostSelection/>", () => {
         configuredClusterNodes={[
           {
             id: "host-dh38bjw9",
-            name: "host-dh38bjw9",
             status: {
               condition: "STATUS_CONDITION_READY",
             },
@@ -233,7 +229,6 @@ describe("<HostSelection/>", () => {
                   nodes: [
                     {
                       id: "host-dh38bjw9",
-                      name: "host-dh38bjw9",
                       status: {
                         condition: "STATUS_CONDITION_READY",
                       },
@@ -243,7 +238,6 @@ describe("<HostSelection/>", () => {
                 configuredClusterNodes={[
                   {
                     id: "host-dh38bjw9",
-                    name: "host-dh38bjw9",
                     status: {
                       condition: "STATUS_CONDITION_READY",
                     },

--- a/apps/cluster-orch/src/utils/NodeTableColumns.tsx
+++ b/apps/cluster-orch/src/utils/NodeTableColumns.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { cm } from "@orch-ui/apis";
+import { cm, infra } from "@orch-ui/apis";
 import { StatusIcon, TableColumn } from "@orch-ui/components";
 import {
   getInfraPath,
@@ -13,7 +13,11 @@ import {
 } from "@orch-ui/utils";
 import { Link } from "react-router-dom";
 
-const name: TableColumn<cm.NodeInfo> = {
+export type CombinedNodeHostItem = Partial<infra.HostResourceRead> &
+  cm.NodeInfo;
+export type CombinedNodeHostList = CombinedNodeHostItem[];
+
+const name: TableColumn<CombinedNodeHostItem> = {
   Header: "Host Name",
   accessor: (node) => {
     if (node.name) {
@@ -22,7 +26,7 @@ const name: TableColumn<cm.NodeInfo> = {
       return node.id;
     }
   },
-  Cell: (table: { row: { original: cm.NodeInfo } }) => {
+  Cell: (table: { row: { original: CombinedNodeHostItem } }) => {
     return table.row.original.id ? (
       <Link
         to={getInfraPath(hostDetailsRoute, {
@@ -39,14 +43,14 @@ const name: TableColumn<cm.NodeInfo> = {
   },
 };
 
-const nameWithoutLink: TableColumn<cm.NodeInfo> = {
+const nameWithoutLink: TableColumn<CombinedNodeHostItem> = {
   Header: "Host Name",
   accessor: (node) => node.name || node.id,
 };
 
-const status: TableColumn<cm.NodeInfo> = {
+const status: TableColumn<CombinedNodeHostItem> = {
   Header: "Readiness",
-  accessor: (item: cm.NodeInfo) => nodeStatusToText(item.status),
+  accessor: (item: CombinedNodeHostItem) => nodeStatusToText(item.status),
   Cell: (table: { row: { original: cm.NodeInfo } }) => {
     const row = table.row.original;
     return (
@@ -63,12 +67,12 @@ const guid: TableColumn<cm.NodeInfo> = {
   accessor: (nodes) => nodes.id ?? "-",
 };
 
-const os: TableColumn<cm.NodeInfo> = {
+const os: TableColumn<CombinedNodeHostItem> = {
   Header: "Operating System",
-  accessor: (nodes) => nodes.os ?? "-",
+  accessor: (nodes) => nodes.instance?.os?.name ?? "-",
 };
 
-const role: TableColumn<cm.NodeInfo> = {
+const role: TableColumn<CombinedNodeHostItem> = {
   Header: "Role",
   accessor: (nodes) => {
     let roleUpdate = "";
@@ -88,8 +92,8 @@ const role: TableColumn<cm.NodeInfo> = {
 };
 
 const roleSelect = (
-  popupFn: (node: cm.NodeInfo) => JSX.Element,
-): TableColumn<cm.NodeInfo> => ({
+  popupFn: (node: CombinedNodeHostItem) => JSX.Element,
+): TableColumn<CombinedNodeHostItem> => ({
   Header: "Role",
   textAlign: "left",
   padding: "0",
@@ -97,8 +101,8 @@ const roleSelect = (
 });
 
 const actions = (
-  popupFn: (node: cm.NodeInfo) => JSX.Element,
-): TableColumn<cm.NodeInfo> => ({
+  popupFn: (node: CombinedNodeHostItem) => JSX.Element,
+): TableColumn<CombinedNodeHostItem> => ({
   Header: "Actions",
   textAlign: "center",
   padding: "0",

--- a/library/utils/mocks/cluster-orch/data/nodes.ts
+++ b/library/utils/mocks/cluster-orch/data/nodes.ts
@@ -33,6 +33,7 @@ export const nodeThree: cm.NodeInfo = {
   id: assignedWorkloadHostThreeId,
   status: {
     condition: "STATUS_CONDITION_READY",
+    reason: "Running",
   },
   role: "controlplane",
 };
@@ -41,6 +42,7 @@ export const nodeFour: cm.NodeInfo = {
   id: assignedWorkloadHostFourId,
   status: {
     condition: "STATUS_CONDITION_READY",
+    reason: "Running",
   },
   role: "all",
 };
@@ -49,6 +51,7 @@ export const nodeFive: cm.NodeInfo = {
   id: provisionedHostOneId,
   status: {
     condition: "STATUS_CONDITION_READY",
+    reason: "Running",
   },
   role: "all",
 };

--- a/library/utils/mocks/infra/mocks.ts
+++ b/library/utils/mocks/infra/mocks.ts
@@ -305,6 +305,27 @@ export const handlers = [
       );
     }
   }),
+  rest.get(`${baseURL}/regions/*/sites/:resourceId`, async (req, res, ctx) => {
+    const { resourceId } =
+      req.params as unknown as infra.SiteServiceGetSiteApiArg;
+    const notFoundResponse = {
+      detail: "rpc error: code = NotFound desc = ent: resourceId not found",
+      status: 404,
+    };
+    if (resourceId) {
+      const site = siteStore.getSiteById({ resourceId });
+      if (site) {
+        return res(
+          ctx.status(200),
+          ctx.json<infra.SiteServiceGetSiteApiResponse>(site),
+        );
+      } else {
+        return res(ctx.status(404), ctx.json(notFoundResponse));
+      }
+    } else {
+      return res(ctx.status(404), ctx.json(notFoundResponse));
+    }
+  }),
   rest.post(`${baseURL}/sites`, async (req, res, ctx) => {
     const body = await req.json<infra.SiteResourceWrite>();
     if (body.regionId) {

--- a/library/utils/mocks/infra/store/sites.ts
+++ b/library/utils/mocks/infra/store/sites.ts
@@ -259,6 +259,15 @@ export class SiteStore extends BaseStore<
     return this.resources;
   }
 
+  getSiteById(params?: {
+    resourceId: string | null;
+  }): infra.SiteResourceRead | undefined {
+    if (params?.resourceId != null) {
+      return this.resources.find((r) => r.resourceId === params.resourceId);
+    }
+    return undefined;
+  }
+
   convert(body: infra.SiteResourceWrite, id?: string): infra.SiteResourceRead {
     const randomString = StoreUtils.randomString();
     const siteID = id ?? `site-${randomString}`;


### PR DESCRIPTION
# PR Description

changes to display host readiness and OS details in cluster edit view

## Changes

- API call to fetch host resource corresponding to cluster `node` id
- Added additional Host readiness column in host table of cluster edit view
- Reading `os` info from host response instead of cluster `node`
- Removed `name` and `os` fields from mock data as the fields no longer exists in cluster `node`
- Added unit test to verify that the host details are rendered in cluster edit view


## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated