### PR TITLE
Add remaining vpro integrations

### DIFF
--- a/apps/infra/src/components/organism/ConfigureAllHosts/ConfigureAllHosts.tsx
+++ b/apps/infra/src/components/organism/ConfigureAllHosts/ConfigureAllHosts.tsx
@@ -151,10 +151,7 @@ const ConfigureAllHosts = () => {
           <Flex cols={[6]} gap="2" align="start">
             <div>
               <Heading semanticLevel={6}>vPro</Heading>
-              <p>
-                Enable vPro for lorem ipsum dolorem, remote management with
-                enhanced security. Lorem minimum HW requirements.
-              </p>
+              <p>Enable vPro</p>
               <ToggleSwitch
                 name="vpro"
                 isSelected={commonHostData.vPro}

--- a/apps/infra/src/components/organism/HostProvisionEditDrawer/HostProvisionEditDrawer.tsx
+++ b/apps/infra/src/components/organism/HostProvisionEditDrawer/HostProvisionEditDrawer.tsx
@@ -88,6 +88,10 @@ const HostProvisionEditDrawer = ({
   const [securityFeature, setSecurityFeature] = useState<
     NonNullable<HostData["instance"]>["securityFeature"] | undefined
   >(host?.instance?.securityFeature);
+
+  const [enableVpro, setEnableVpro] = useState<boolean | undefined>(
+    host?.enableVpro,
+  );
   const [publicSshKey, setPublicSshKey] = useState<string | undefined>(
     host?.instance?.localAccountID,
   );
@@ -200,16 +204,14 @@ const HostProvisionEditDrawer = ({
                   <Flex cols={[6]} gap="2" align="start">
                     <div>
                       <Heading semanticLevel={6}>vPro</Heading>
-                      <p>
-                        Enable vPro for lorem ipsum dolorem, remote management
-                        with enhanced security. Lorem minimum HW requirements.
-                      </p>
+                      <p>Enable vPro</p>
                       <ToggleSwitch
                         name="vpro"
-                        isSelected={false}
+                        isSelected={enableVpro}
                         size={ToggleSwitchSize.Large}
+                        onChange={(isSelected) => setEnableVpro(isSelected)}
                       >
-                        Disabled
+                        {enableVpro ? "Enabled" : "Disabled"}
                       </ToggleSwitch>
                     </div>
                     <div>
@@ -301,6 +303,7 @@ const HostProvisionEditDrawer = ({
                         templateName,
                         templateVersion,
                         metadata,
+                        enableVpro,
                       },
                     }),
                   );

--- a/apps/infra/src/components/organism/ReviewAndCustomize/ReviewAndCustomize.tsx
+++ b/apps/infra/src/components/organism/ReviewAndCustomize/ReviewAndCustomize.tsx
@@ -174,7 +174,13 @@ const ReviewAndCustomize = () => {
             <div className="hosts-overview-details">
               <div></div>
               <div>
-                <Text size={TextSize.Small}>vPRO : </Text>
+                <Text size={TextSize.Small}>
+                  vPRO :{" "}
+                  {countDistinctValuesWithLabels(hostValues, "enableVpro", {
+                    true: "Enabled",
+                    false: "Disabled",
+                  })}
+                </Text>
               </div>
               <div>
                 <Text size={TextSize.Small}>

--- a/apps/infra/src/components/pages/HostDetails/HostDetails.tsx
+++ b/apps/infra/src/components/pages/HostDetails/HostDetails.tsx
@@ -119,6 +119,8 @@ const HostDetails: React.FC = () => {
     },
   ); // Host's Site details
 
+  const [patchHost] = infra.useHostServicePatchHostMutation();
+
   // Below useEffects will set the host/site data to display
   useEffect(() => {
     if (!hostQuery.isLoading && !hostQuery.isError && hostQuery.data && id) {
@@ -312,6 +314,39 @@ const HostDetails: React.FC = () => {
     message: host.powerStatus ?? "Unknown",
   };
 
+  const handleStartPress = () => {
+    patchHost({
+      projectName: SharedStorage.project?.name ?? "",
+      resourceId: host.resourceId as string,
+      hostResource: {
+        name: host.name,
+        desiredPowerState: "POWER_STATE_ON",
+      },
+    }).unwrap();
+  };
+
+  const handleStopPress = () => {
+    patchHost({
+      projectName: SharedStorage.project?.name ?? "",
+      resourceId: host.resourceId as string,
+      hostResource: {
+        name: host.name,
+        desiredPowerState: "POWER_STATE_OFF",
+      },
+    }).unwrap();
+  };
+
+  const handleRestartPress = () => {
+    patchHost({
+      projectName: SharedStorage.project?.name ?? "",
+      resourceId: host.resourceId as string,
+      hostResource: {
+        name: host.name,
+        desiredPowerState: "POWER_STATE_RESET",
+      },
+    }).unwrap();
+  };
+
   return (
     <div className={cssSelectorIhd} data-cy={dataCyIhd}>
       {/* HostDetails Heading */}
@@ -320,41 +355,47 @@ const HostDetails: React.FC = () => {
           {host.name != "" ? host.name : host.resourceId}
         </Heading>
         <div className="primary-actions">
-          <ButtonGroup className="button-group">
-            <Button
-              size={ButtonSize.Large}
-              variant={ButtonVariant.Secondary}
-              endSlot={<Icon icon="play" />}
-              isDisabled={
-                host.powerStatusIndicator === "STATUS_INDICATION_IDLE"
-              }
-              data-cy={`${dataCyIhd}StartBtn`}
-            >
-              Start
-            </Button>
-            <Button
-              size={ButtonSize.Large}
-              variant={ButtonVariant.Secondary}
-              endSlot={<Icon icon="redo" />}
-              isDisabled={
-                host.powerStatusIndicator !== "STATUS_INDICATION_IDLE"
-              }
-              data-cy={`${dataCyIhd}RestartBtn`}
-            >
-              Restart
-            </Button>
-            <Button
-              size={ButtonSize.Large}
-              variant={ButtonVariant.Secondary}
-              endSlot={<Icon icon="square" />}
-              isDisabled={
-                host.powerStatusIndicator !== "STATUS_INDICATION_IDLE"
-              }
-              data-cy={`${dataCyIhd}StopBtn`}
-            >
-              Stop
-            </Button>
-          </ButtonGroup>
+          {host.amtSku !== "Unknown" && (
+            <ButtonGroup className="button-group">
+              <Button
+                size={ButtonSize.Large}
+                variant={ButtonVariant.Secondary}
+                endSlot={<Icon icon="play" />}
+                isDisabled={
+                  host.powerStatusIndicator === "STATUS_INDICATION_IDLE"
+                }
+                data-cy={`${dataCyIhd}StartBtn`}
+                onPress={handleStartPress}
+              >
+                Start
+              </Button>
+              <Button
+                size={ButtonSize.Large}
+                variant={ButtonVariant.Secondary}
+                endSlot={<Icon icon="redo" />}
+                isDisabled={
+                  host.powerStatusIndicator !== "STATUS_INDICATION_IDLE"
+                }
+                data-cy={`${dataCyIhd}RestartBtn`}
+                onPress={handleRestartPress}
+              >
+                Restart
+              </Button>
+              <Button
+                size={ButtonSize.Large}
+                variant={ButtonVariant.Secondary}
+                endSlot={<Icon icon="square" />}
+                isDisabled={
+                  host.powerStatusIndicator !== "STATUS_INDICATION_IDLE"
+                }
+                data-cy={`${dataCyIhd}StopBtn`}
+                onPress={handleStopPress}
+              >
+                Stop
+              </Button>
+            </ButtonGroup>
+          )}
+
           <HostDetailsActions
             basePath="../"
             host={host}

--- a/apps/infra/src/components/pages/HostProvision/host-provision.utils.ts
+++ b/apps/infra/src/components/pages/HostProvision/host-provision.utils.ts
@@ -150,6 +150,7 @@ export const useProvisioning = () => {
                 name: host.name,
                 serialNumber: host.serialNumber || undefined,
                 uuid: host.uuid || undefined,
+                enableVpro: host.enableVpro,
               },
               projectName: SharedStorage.project?.name ?? "",
             }).unwrap(),

--- a/apps/infra/src/store/provisionHost.ts
+++ b/apps/infra/src/store/provisionHost.ts
@@ -22,6 +22,7 @@ export type HostData = infra.HostResourceWrite & {
   templateName?: string;
   templateVersion?: string;
   error?: string;
+  enableVpro?: boolean;
 };
 
 export interface HostProvisionFormState {
@@ -59,7 +60,7 @@ export const initialState: HostProvisionState = {
   },
   hosts: {},
   commonHostData: {
-    vPro: true,
+    vPro: false,
     securityFeature: true,
   },
   autoOnboard: true,
@@ -230,6 +231,8 @@ export const provisionHost = createSlice({
         host.instance.securityFeature = state.commonHostData.securityFeature
           ? "SECURITY_FEATURE_SECURE_BOOT_AND_FULL_DISK_ENCRYPTION"
           : "SECURITY_FEATURE_NONE";
+
+        host.enableVpro = state.commonHostData.vPro;
         host.instance.localAccountID =
           state.commonHostData.publicSshKey?.resourceId;
         host.metadata = state.commonHostData.metadata;
@@ -338,6 +341,7 @@ export const selectNoChangesInHosts = (state: RootState) =>
         host.instance?.securityFeature,
         commonData.securityFeature,
       ) &&
+      host.enableVpro === commonData.vPro &&
       host.instance?.localAccountID === commonData.publicSshKey?.resourceId &&
       isEqual(host.metadata ?? [], commonData.metadata ?? []);
 


### PR DESCRIPTION
# PR Description

There are some remaining vPro integrations with backend that have been done in this PR.

1. Add api integration for power buttons in host details page.
2. Add `enableVpro` flag inside the host provisioning flow. It is sent as part of the payload to the Register Host api.
3. Allow users to change the vPro setting inside the host edit drawer during the provisioning flow.
4. Show number of enabled/disabled vPro hosts as an aggregate in the Review Summary page.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated