### PR TITLE
Show vpro selection in host summary accordion

### DIFF
--- a/apps/infra/src/components/organism/ReviewAndCustomize/HostReviewDetails.tsx
+++ b/apps/infra/src/components/organism/ReviewAndCustomize/HostReviewDetails.tsx
@@ -21,20 +21,20 @@ const HostReviewDetails = ({ host }: HostReviewDetailsProps) => {
     <div className="host-review-details">
       <Flex cols={[2, 4]} align="start">
         <b>Serial number</b>
-        <Text>{host.serialNumber}</Text>
+        <Text>{host.serialNumber || "-"}</Text>
         <b>Security</b>
         <Text>
           Secure Boot and Full Disk Encryption:{" "}
           {isSbfde(host) ? "Enabled" : "Disabled"}
         </Text>
         <b>UUID</b>
-        <Text>{host.uuid}</Text>
+        <Text>{host.uuid || "-"}</Text>
         <div></div>
-        <Text>vPro:</Text>
+        <Text>vPro: {host.enableVpro ? "Enabled" : "Disabled"}</Text>
         <div></div>
         <div></div>
         <div></div>
-        <Text>SSH Key: {host.instance?.localAccountID}</Text>
+        <Text>SSH Key: {host.instance?.localAccountID || "-"}</Text>
         <div></div>
         <div></div>
         <b>Trusted Compute</b>


### PR DESCRIPTION
# PR Description

In the host provisioning flow's review page, the accordions don't show whether vPro is enabled for the host or not. This PR shows the value.

<img width="2545" height="1227" alt="image" src="https://github.com/user-attachments/assets/88e40dfa-14e3-4c72-b26a-0d414e3ece8d" />

## Changes

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated