### PR TITLE
Increased helm url field maxlength limit to 1000 characters

### DIFF
--- a/apps/app-orch/src/components/organisms/deploymentPackages/DeploymentPackageHelmChartInfoForm/DeploymentPackageHelmChartInfoForm.cy.tsx
+++ b/apps/app-orch/src/components/organisms/deploymentPackages/DeploymentPackageHelmChartInfoForm/DeploymentPackageHelmChartInfoForm.cy.tsx
@@ -33,10 +33,10 @@ describe("<DeploymentPackageHelmChartInfoForm />", () => {
   });
 
   describe("validation", () => {
-    it("cannot put more than 70 characters for Helm Chart URL", () => {
-      const longValue = "a".repeat(71);
+    it("cannot put more than 1000 characters for Helm Chart URL", () => {
+      const longValue = "a".repeat(1001);
       pom.el["helm-chart-url"].type(longValue);
-      const shorterValue = "a".repeat(70);
+      const shorterValue = "a".repeat(1000);
       pom.el["helm-chart-url"].invoke("val").should("equal", shorterValue);
     });
 

--- a/apps/app-orch/src/components/organisms/deploymentPackages/DeploymentPackageHelmChartInfoForm/DeploymentPackageHelmChartInfoForm.tsx
+++ b/apps/app-orch/src/components/organisms/deploymentPackages/DeploymentPackageHelmChartInfoForm/DeploymentPackageHelmChartInfoForm.tsx
@@ -170,13 +170,13 @@ const DeploymentPackageHelmChartInfoForm = () => {
             control={control}
             rules={{
               required: true,
-              maxLength: 70,
+              maxLength: 1000,
             }}
             render={({ field, formState }) => (
               <TextField
                 {...field}
                 data-cy="helm-chart-url"
-                maxLength={70}
+                maxLength={1000}
                 onInput={(e) => {
                   const value = e.currentTarget.value;
                   dispatch(setHelmChartURL(value));
@@ -185,7 +185,7 @@ const DeploymentPackageHelmChartInfoForm = () => {
                   formState.errors.helmChartURL?.type === "required"
                     ? "Helm Chart URL is required"
                     : formState.errors.helmChartURL?.type === "maxLength"
-                      ? "Helm Chart URL can't be more than 70 characters"
+                      ? "Helm Chart URL can't be more than 1000 characters"
                       : null
                 }
                 validationState={


### PR DESCRIPTION
# PR Description

Increased helm url field maxlength limit to 1000 characters

## Changes

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated