### PR TITLE
Make deauthorization reason mandatory and disable confirmBtn

### DIFF
--- a/apps/infra/src/components/organism/hosts/DeauthorizeHostStandalone/DeauthorizeHostStandalone.tsx
+++ b/apps/infra/src/components/organism/hosts/DeauthorizeHostStandalone/DeauthorizeHostStandalone.tsx
@@ -45,7 +45,7 @@ const DeauthorizeHostStandalone = ({
   setDeauthorizeConfirmationOpen,
 }: DeauthorizeHostStandaloneProps) => {
   const cy = { "data-cy": dataCy };
-  const [deauthorizeReason, setDeauthorizeReason] = useState<string>();
+  const [deauthorizeReason, setDeauthorizeReason] = useState<string>("");
   const { control: controlDeauthBasicInfo } = useForm<DeauthInputs>({
     mode: "all",
   });
@@ -71,10 +71,12 @@ const DeauthorizeHostStandalone = ({
         render={({ field }) => (
           <TextField
             {...field}
-            label="Deauthorize reason (Optional)"
+            label="Reason for deauthorization"
             data-cy="reason"
             onInput={(e) => {
-              setDeauthorizeReason(e.currentTarget.value);
+              const value = e.currentTarget.value;
+              setDeauthorizeReason(value);
+              field.onChange(value);
             }}
             size={InputSize.Large}
             className="text-field-align"
@@ -109,6 +111,9 @@ const DeauthorizeHostStandalone = ({
       content={deauthDialogContent}
       isOpen={isDeauthConfirmationOpen}
       confirmBtnVariant={ButtonVariant.Alert}
+      confirmBtnDisabled={
+        !deauthorizeReason || deauthorizeReason.trim().length === 0
+      }
       confirmCb={() => deauthorizeHostFn(deauthorizeReason ?? "")}
       confirmBtnText="Deauthorize"
       cancelCb={() => setDeauthorizeConfirmationOpen(false)}

--- a/library/components/atomic-design/atoms/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/library/components/atomic-design/atoms/ConfirmationDialog/ConfirmationDialog.tsx
@@ -45,6 +45,10 @@ export interface ConfirmationDialogProps {
    */
   confirmBtnVariant?: ButtonVariant;
   /**
+   * Whether the confirm button is disabled
+   */
+  confirmBtnDisabled?: boolean;
+  /**
    * Callback invoked when the cancel button is clicked
    */
   cancelCb?: () => void;
@@ -100,6 +104,7 @@ export const ConfirmationDialog = ({
   confirmCb,
   confirmBtnText = "Confirm",
   confirmBtnVariant = ButtonVariant.Action,
+  confirmBtnDisabled = false,
   cancelCb,
   cancelBtnText = "Cancel",
   cancelBtnVariant = ButtonVariant.Secondary,
@@ -151,6 +156,7 @@ export const ConfirmationDialog = ({
                 <Button
                   className="cd-button"
                   variant={confirmBtnVariant}
+                  isDisabled={confirmBtnDisabled}
                   onPress={() => {
                     if (confirmCb) confirmCb();
                     close();


### PR DESCRIPTION
# PR Description

The "Deauthorize" button will be disabled until the user enters a character inside the "Reason for deauthorization" textfield.

<img width="1468" height="796" alt="image" src="https://github.com/user-attachments/assets/2f3a85b9-3bad-4af1-aef8-1adf429de5dc" />

## Changes

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated