### PR TITLE
Add enableVpro flag to the Register Host api

### DIFF
--- a/apps/infra/src/components/pages/HostProvision/host-provision.utils.ts
+++ b/apps/infra/src/components/pages/HostProvision/host-provision.utils.ts
@@ -153,6 +153,7 @@ export const useProvisioning = () => {
               registerHostApi({
                 hostRegister: {
                   autoOnboard,
+                  enableVpro: host.enableVpro,
                   name: host.name,
                   serialNumber: host.serialNumber || undefined,
                   uuid: host.uuid || undefined,


### PR DESCRIPTION
# PR Description

Add the missing `enableVpro` flag to the host registration api.

## Changes

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated