### PR TITLE
refetching application data from API instead of accessing it from cache

### DIFF
--- a/apps/app-orch/src/components/organisms/setup-deployments/OverrideProfileValues/OverrideProfileTable.tsx
+++ b/apps/app-orch/src/components/organisms/setup-deployments/OverrideProfileValues/OverrideProfileTable.tsx
@@ -63,6 +63,7 @@ const OverrideProfileTable = ({
             applicationName: ar.name,
             version: ar.version,
           },
+          { forceRefetch: true }, // as its only get call forceRefetch is used, as opposed to invalidateTags which would refetch all the resources
         ),
       );
     });


### PR DESCRIPTION
# PR Description

Refetching application data from API instead of accessing it from cache

## Changes

- Added forceRefetch to ignore cache and fetch data from API.
- When anything is changed in the DP tar files, still the endpoint params remains same hence browser returns data from cache instead of refetching it.
- Adding forceRefetch flag forces to ignore cache and fetch latest data

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated