### PR TITLE
Alerts data refresh on component mount and added polling to API

### DIFF
--- a/apps/admin/src/components/organisms/AlertDefinitionsList/AlertDefinitionsList.tsx
+++ b/apps/admin/src/components/organisms/AlertDefinitionsList/AlertDefinitionsList.tsx
@@ -74,11 +74,6 @@ const AlertDefinitionsList = () => {
                 message: "Alert definitions Successfully updated",
               }),
             );
-            dispatch(
-              omApi.observabilityMonitor.util.invalidateTags([
-                { type: "alert-definition" },
-              ]),
-            );
             setActions([]);
           })
           .catch(() => {
@@ -266,11 +261,6 @@ const AlertDefinitionsList = () => {
               setActions([]);
               setAlertDefinitionsTableData(
                 alertDefinitions?.alertDefinitions ?? [],
-              );
-              dispatch(
-                omApi.observabilityMonitor.util.invalidateTags([
-                  { type: "alert-definition" },
-                ]),
               );
             }}
           >

--- a/apps/admin/src/components/organisms/AlertDefinitionsList/AlertDefinitionsList.tsx
+++ b/apps/admin/src/components/organisms/AlertDefinitionsList/AlertDefinitionsList.tsx
@@ -5,7 +5,7 @@
 
 import { omApi } from "@orch-ui/apis";
 import { OrchTable } from "@orch-ui/components";
-import { SharedStorage } from "@orch-ui/utils";
+import { API_INTERVAL, SharedStorage } from "@orch-ui/utils";
 import { Button } from "@spark-design/react";
 import { ToastState } from "@spark-design/tokens";
 import { useEffect, useState } from "react";
@@ -39,13 +39,25 @@ const AlertDefinitionsList = () => {
     isLoading,
     isError,
     error,
-  } = omApi.useGetProjectAlertDefinitionsQuery({
-    projectName: SharedStorage.project?.name ?? "",
-  });
+    refetch,
+    isUninitialized,
+  } = omApi.useGetProjectAlertDefinitionsQuery(
+    {
+      projectName: SharedStorage.project?.name ?? "",
+    },
+    { pollingInterval: API_INTERVAL },
+  );
 
   useEffect(() => {
     setAlertDefinitionsTableData(alertDefinitions?.alertDefinitions ?? []);
   }, [alertDefinitions, isSuccess]);
+
+  // Refetch API if previously called and project changes to ensure fresh data
+  useEffect(() => {
+    if (!isUninitialized) {
+      refetch();
+    }
+  }, [SharedStorage.project?.name, refetch, isUninitialized]);
 
   const updateAlertDefinitions = async () => {
     const requests: Promise<unknown>[] = [];
@@ -61,6 +73,11 @@ const AlertDefinitionsList = () => {
                 state: ToastState.Success,
                 message: "Alert definitions Successfully updated",
               }),
+            );
+            dispatch(
+              omApi.observabilityMonitor.util.invalidateTags([
+                { type: "alert-definition" },
+              ]),
             );
             setActions([]);
           })
@@ -249,6 +266,11 @@ const AlertDefinitionsList = () => {
               setActions([]);
               setAlertDefinitionsTableData(
                 alertDefinitions?.alertDefinitions ?? [],
+              );
+              dispatch(
+                omApi.observabilityMonitor.util.invalidateTags([
+                  { type: "alert-definition" },
+                ]),
               );
             }}
           >


### PR DESCRIPTION
# PR Description

Alerts data refresh on component mount to override browser cache and added polling to API

## Changes

- Added Polling to API
- Added block to refetch data on component mount overriding the browser cache

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated