### PR TITLE
ui: regenerate tenancy API for new tenancy-manager and migrate callers

### DIFF
--- a/apps/admin/src/components/organisms/CreateEditProject/CreateEditProject.pom.ts
+++ b/apps/admin/src/components/organisms/CreateEditProject/CreateEditProject.pom.ts
@@ -23,7 +23,7 @@ type SuccessApiAliases = "createProject";
 type ErrorApiAliases = "createProjectError";
 type ApiAliases = SuccessApiAliases | ErrorApiAliases;
 
-const successEndpoints: CyApiDetails<SuccessApiAliases, tm.ProjectProjectPost> =
+const successEndpoints: CyApiDetails<SuccessApiAliases, tm.ProjectWrite> =
   {
     createProject: {
       route: projectByIdRoute,

--- a/apps/admin/src/components/organisms/CreateEditProject/CreateEditProject.tsx
+++ b/apps/admin/src/components/organisms/CreateEditProject/CreateEditProject.tsx
@@ -50,7 +50,7 @@ export const CreateEditProject = ({
 }: CreateEditProjectProps) => {
   const cy = { "data-cy": dataCy };
 
-  const { usePutV1ProjectsProjectProjectMutation: usePutProject } = tm;
+  const { usePutV1ProjectsByNameMutation: usePutProject } = tm;
 
   const [createProject] = usePutProject();
   const [projectNameInput, setProjectNameInput] = useState<string>("");
@@ -87,9 +87,9 @@ export const CreateEditProject = ({
   const handleCreateSubmit = () => {
     setSubmitError("");
     const p = createProject({
-      "project.Project": toApiName(projectNameInput),
+      name: toApiName(projectNameInput),
       updateIfExists: false,
-      projectProjectPost: {
+      projectWrite: {
         description: projectDescriptionInput || projectNameInput,
       },
     });

--- a/apps/admin/src/components/organisms/DeleteProjectDialog/DeleteProjectDialog.tsx
+++ b/apps/admin/src/components/organisms/DeleteProjectDialog/DeleteProjectDialog.tsx
@@ -40,7 +40,7 @@ const DeleteProjectDialog = ({
 }: DeleteProjectDialogProps) => {
   const cy = { "data-cy": dataCy };
 
-  const { useDeleteV1ProjectsProjectProjectMutation: useDeleteProject } = tm;
+  const { useDeleteV1ProjectsByNameMutation: useDeleteProject } = tm;
 
   const [deleteProjectName, setDeleteProjectName] = useState<string>("");
   const [deleteProject] = useDeleteProject();
@@ -53,7 +53,7 @@ const DeleteProjectDialog = ({
       return;
     }
     deleteProject({
-      "project.Project": projectName,
+      name: projectName,
     })
       .then((res) => {
         if ((res as { error: FetchBaseQueryError | SerializedError }).error) {

--- a/apps/admin/src/components/organisms/ProjectsTable/ProjectsTable.tsx
+++ b/apps/admin/src/components/organisms/ProjectsTable/ProjectsTable.tsx
@@ -180,7 +180,7 @@ const ProjectsTable = ({ hasRole = hasRoleDefault }: ProjectsTableProps) => {
   const searchTerm = searchParams.get("searchTerm") ?? undefined;
 
   const { data: memberProjects } = listProjects(
-    { "member-role": true },
+    {},
     {
       // If Modal is open i.e if the modal state is defined then skip polling
       ...(!projectModalState ? { pollingInterval: pollingInterval } : {}),

--- a/apps/root/src/components/pages/DashboardSummaries/DashboardSummaries.tsx
+++ b/apps/root/src/components/pages/DashboardSummaries/DashboardSummaries.tsx
@@ -40,7 +40,7 @@ export const DashboardSummaries = () => {
   const { deploymentId } = useParams<urlParams>();
   const [projectName, setProjectName] = useState<string>("");
 
-  const { data: projects } = tm.useListV1ProjectsQuery({ "member-role": true });
+  const { data: projects } = tm.useListV1ProjectsQuery({});
   useEffect(() => {
     setProjectName(
       projects?.find((proj) => proj.name === SharedStorage.project?.name)?.spec

--- a/library/apis/generate-api.sh
+++ b/library/apis/generate-api.sh
@@ -27,8 +27,8 @@ NC='\033[0m' # No Color
 
 echo -e "${CYAN}Generate RTK endpoints APIs${NC}"
 
-# echo -e "${CYAN}Generate TENANT_MANAGER RTK endpoints APIs${NC}"
-# npx @rtk-query/codegen-openapi ${prefix}tenancy/tenancyDataModel.config.json
+echo -e "${CYAN}Generate TENANT_MANAGER RTK endpoints APIs${NC}"
+npx @rtk-query/codegen-openapi ${prefix}tenancy/tenancyDataModel.config.json
 
 echo -e "${CYAN}Generate EDGE_INFRA_MANAGER RTK endpoints APIs${NC}"
 npx @rtk-query/codegen-openapi ${prefix}infra/infraApis.config.json

--- a/library/apis/tenancy/openapi.yaml
+++ b/library/apis/tenancy/openapi.yaml
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+openapi: 3.0.3
+info:
+  title: Tenancy Manager API
+  description: REST API exposed by the Tenancy Manager (orch-utils/tenancy-manager). Replaces the legacy nexus-api-gw tenancy-datamodel endpoints.
+  version: "1.0.0"
+servers:
+  - url: /
+paths:
+  /v1/orgs:
+    get:
+      tags: [Org]
+      summary: List organizations
+      operationId: listV1Orgs
+      responses:
+        "200":
+          description: List of organizations
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrgList"
+  /v1/orgs/{name}:
+    parameters:
+      - $ref: "#/components/parameters/OrgName"
+    get:
+      tags: [Org]
+      summary: Get organization
+      operationId: getV1OrgsByName
+      responses:
+        "200":
+          description: Organization
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Org"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    put:
+      tags: [Org]
+      summary: Create or update organization
+      operationId: putV1OrgsByName
+      parameters:
+        - in: query
+          name: update_if_exists
+          description: If false, the call fails with 409 when the org already exists. Defaults to true.
+          required: false
+          schema:
+            type: boolean
+            default: true
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OrgWrite"
+      responses:
+        "200":
+          description: Created or updated organization
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Org"
+        "409":
+          $ref: "#/components/responses/Conflict"
+    delete:
+      tags: [Org]
+      summary: Delete organization
+      operationId: deleteV1OrgsByName
+      responses:
+        "200":
+          description: OK
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/orgs/{name}/status:
+    parameters:
+      - $ref: "#/components/parameters/OrgName"
+    get:
+      tags: [Org]
+      summary: Get organization status (includes recently deleted)
+      operationId: getV1OrgsByNameStatus
+      responses:
+        "200":
+          description: Organization status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Org"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/projects:
+    get:
+      tags: [Project]
+      summary: List projects in the caller's org scope
+      operationId: listV1Projects
+      parameters:
+        - in: query
+          name: org
+          description: Filter to a single org by name. When omitted, the caller's resolved org scope (from JWT) is used.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: List of projects
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectList"
+  /v1/projects/{name}:
+    parameters:
+      - $ref: "#/components/parameters/ProjectName"
+    get:
+      tags: [Project]
+      summary: Get project
+      operationId: getV1ProjectsByName
+      parameters:
+        - in: query
+          name: org
+          description: Disambiguate by org when the same project name exists under multiple orgs.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+    put:
+      tags: [Project]
+      summary: Create or update project
+      operationId: putV1ProjectsByName
+      parameters:
+        - in: query
+          name: org
+          description: Target org (required for creation when the caller has scope to multiple orgs).
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: update_if_exists
+          description: If false, the call fails with 409 when the project already exists. Defaults to true.
+          required: false
+          schema:
+            type: boolean
+            default: true
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProjectWrite"
+      responses:
+        "200":
+          description: Created or updated project
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "409":
+          $ref: "#/components/responses/Conflict"
+    delete:
+      tags: [Project]
+      summary: Delete project
+      operationId: deleteV1ProjectsByName
+      parameters:
+        - in: query
+          name: org
+          description: Disambiguate by org when the same project name exists under multiple orgs.
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+  /v1/projects/{name}/status:
+    parameters:
+      - $ref: "#/components/parameters/ProjectName"
+    get:
+      tags: [Project]
+      summary: Get project status (includes recently deleted)
+      operationId: getV1ProjectsByNameStatus
+      parameters:
+        - in: query
+          name: org
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Project status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Project"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+
+components:
+  parameters:
+    OrgName:
+      in: path
+      name: name
+      required: true
+      description: Org name
+      schema:
+        type: string
+    ProjectName:
+      in: path
+      name: name
+      required: true
+      description: Project name
+      schema:
+        type: string
+  responses:
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Conflict:
+      description: Conflict
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+    StatusDetail:
+      type: object
+      properties:
+        statusIndicator:
+          type: string
+          description: One of STATUS_INDICATION_IN_PROGRESS, STATUS_INDICATION_IDLE, STATUS_INDICATION_ERROR.
+        message:
+          type: string
+        timeStamp:
+          type: integer
+          format: int64
+        uID:
+          type: string
+          description: Stable UUID of the resource.
+    OrgStatusWrap:
+      type: object
+      properties:
+        orgStatus:
+          $ref: "#/components/schemas/StatusDetail"
+    ProjectStatusWrap:
+      type: object
+      properties:
+        projectStatus:
+          $ref: "#/components/schemas/StatusDetail"
+    OrgSpec:
+      type: object
+      properties:
+        description:
+          type: string
+    ProjectSpec:
+      type: object
+      properties:
+        description:
+          type: string
+    Org:
+      type: object
+      properties:
+        name:
+          type: string
+        spec:
+          $ref: "#/components/schemas/OrgSpec"
+        status:
+          $ref: "#/components/schemas/OrgStatusWrap"
+    OrgList:
+      type: array
+      items:
+        $ref: "#/components/schemas/Org"
+    OrgWrite:
+      type: object
+      properties:
+        description:
+          type: string
+    Project:
+      type: object
+      properties:
+        name:
+          type: string
+        orgName:
+          type: string
+          description: Name of the org the project belongs to.
+        spec:
+          $ref: "#/components/schemas/ProjectSpec"
+        status:
+          $ref: "#/components/schemas/ProjectStatusWrap"
+    ProjectList:
+      type: array
+      items:
+        $ref: "#/components/schemas/Project"
+    ProjectWrite:
+      type: object
+      properties:
+        description:
+          type: string

--- a/library/apis/tenancy/tenancyDataModel.config.json
+++ b/library/apis/tenancy/tenancyDataModel.config.json
@@ -1,5 +1,5 @@
 {
-  "schemaFile": "../../@orch-utils/tenancy-api-mapping/openapispecs/generated/orch-utils.tenancy-datamodel.openapi.yaml",
+  "schemaFile": "./openapi.yaml",
   "apiFile": "./apiSlice.ts",
   "apiImport": "tdmApi",
   "outputFile": "./tenancyDataModelApi.ts",

--- a/library/apis/tenancy/tenancyDataModelApi.ts
+++ b/library/apis/tenancy/tenancyDataModelApi.ts
@@ -1,5 +1,5 @@
 import { tdmApi as api } from "./apiSlice";
-export const addTagTypes = ["Org", "Project", "Network"] as const;
+export const addTagTypes = ["Org", "Project"] as const;
 const injectedRtkApi = api
   .enhanceEndpoints({
     addTagTypes,
@@ -10,51 +10,40 @@ const injectedRtkApi = api
         query: () => ({ url: `/v1/orgs` }),
         providesTags: ["Org"],
       }),
-      deleteV1OrgsOrgOrg: build.mutation<
-        DeleteV1OrgsOrgOrgApiResponse,
-        DeleteV1OrgsOrgOrgApiArg
+      getV1OrgsByName: build.query<
+        GetV1OrgsByNameApiResponse,
+        GetV1OrgsByNameApiArg
       >({
-        query: (queryArg) => ({
-          url: `/v1/orgs/${queryArg["org.Org"]}`,
-          method: "DELETE",
-        }),
-        invalidatesTags: ["Org"],
-      }),
-      getV1OrgsOrgOrg: build.query<
-        GetV1OrgsOrgOrgApiResponse,
-        GetV1OrgsOrgOrgApiArg
-      >({
-        query: (queryArg) => ({ url: `/v1/orgs/${queryArg["org.Org"]}` }),
+        query: (queryArg) => ({ url: `/v1/orgs/${queryArg.name}` }),
         providesTags: ["Org"],
       }),
-      putV1OrgsOrgOrg: build.mutation<
-        PutV1OrgsOrgOrgApiResponse,
-        PutV1OrgsOrgOrgApiArg
+      putV1OrgsByName: build.mutation<
+        PutV1OrgsByNameApiResponse,
+        PutV1OrgsByNameApiArg
       >({
         query: (queryArg) => ({
-          url: `/v1/orgs/${queryArg["org.Org"]}`,
+          url: `/v1/orgs/${queryArg.name}`,
           method: "PUT",
-          body: queryArg.orgOrgPost,
+          body: queryArg.orgWrite,
           params: { update_if_exists: queryArg.updateIfExists },
         }),
         invalidatesTags: ["Org"],
       }),
-      getV1OrgsOrgOrgFolders: build.query<
-        GetV1OrgsOrgOrgFoldersApiResponse,
-        GetV1OrgsOrgOrgFoldersApiArg
+      deleteV1OrgsByName: build.mutation<
+        DeleteV1OrgsByNameApiResponse,
+        DeleteV1OrgsByNameApiArg
       >({
         query: (queryArg) => ({
-          url: `/v1/orgs/${queryArg["org.Org"]}/Folders`,
+          url: `/v1/orgs/${queryArg.name}`,
+          method: "DELETE",
         }),
-        providesTags: ["Org"],
+        invalidatesTags: ["Org"],
       }),
-      getV1OrgsOrgOrgStatus: build.query<
-        GetV1OrgsOrgOrgStatusApiResponse,
-        GetV1OrgsOrgOrgStatusApiArg
+      getV1OrgsByNameStatus: build.query<
+        GetV1OrgsByNameStatusApiResponse,
+        GetV1OrgsByNameStatusApiArg
       >({
-        query: (queryArg) => ({
-          url: `/v1/orgs/${queryArg["org.Org"]}/status`,
-        }),
+        query: (queryArg) => ({ url: `/v1/orgs/${queryArg.name}/status` }),
         providesTags: ["Org"],
       }),
       listV1Projects: build.query<
@@ -62,108 +51,54 @@ const injectedRtkApi = api
         ListV1ProjectsApiArg
       >({
         query: (queryArg) => ({
-          url: "/v1/projects",
-          // FIXME this parameter has been manually added,
-          // we need to have it in the openapi specs or it will be overridden everytime we auto-generate the code
-          params: { "member-role": queryArg["member-role"] },
+          url: `/v1/projects`,
+          params: { org: queryArg.org },
         }),
         providesTags: ["Project"],
       }),
-      deleteV1ProjectsProjectProject: build.mutation<
-        DeleteV1ProjectsProjectProjectApiResponse,
-        DeleteV1ProjectsProjectProjectApiArg
+      getV1ProjectsByName: build.query<
+        GetV1ProjectsByNameApiResponse,
+        GetV1ProjectsByNameApiArg
       >({
         query: (queryArg) => ({
-          url: `/v1/projects/${queryArg["project.Project"]}`,
-          method: "DELETE",
+          url: `/v1/projects/${queryArg.name}`,
+          params: { org: queryArg.org },
+        }),
+        providesTags: ["Project"],
+      }),
+      putV1ProjectsByName: build.mutation<
+        PutV1ProjectsByNameApiResponse,
+        PutV1ProjectsByNameApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/v1/projects/${queryArg.name}`,
+          method: "PUT",
+          body: queryArg.projectWrite,
+          params: {
+            org: queryArg.org,
+            update_if_exists: queryArg.updateIfExists,
+          },
         }),
         invalidatesTags: ["Project"],
       }),
-      getV1ProjectsProjectProject: build.query<
-        GetV1ProjectsProjectProjectApiResponse,
-        GetV1ProjectsProjectProjectApiArg
+      deleteV1ProjectsByName: build.mutation<
+        DeleteV1ProjectsByNameApiResponse,
+        DeleteV1ProjectsByNameApiArg
       >({
         query: (queryArg) => ({
-          url: `/v1/projects/${queryArg["project.Project"]}`,
-        }),
-        providesTags: ["Project"],
-      }),
-      putV1ProjectsProjectProject: build.mutation<
-        PutV1ProjectsProjectProjectApiResponse,
-        PutV1ProjectsProjectProjectApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/v1/projects/${queryArg["project.Project"]}`,
-          method: "PUT",
-          body: queryArg.projectProjectPost,
-          params: { update_if_exists: queryArg.updateIfExists },
+          url: `/v1/projects/${queryArg.name}`,
+          method: "DELETE",
+          params: { org: queryArg.org },
         }),
         invalidatesTags: ["Project"],
       }),
-      getV1ProjectsProjectProjectNetworks: build.query<
-        GetV1ProjectsProjectProjectNetworksApiResponse,
-        GetV1ProjectsProjectProjectNetworksApiArg
+      getV1ProjectsByNameStatus: build.query<
+        GetV1ProjectsByNameStatusApiResponse,
+        GetV1ProjectsByNameStatusApiArg
       >({
         query: (queryArg) => ({
-          url: `/v1/projects/${queryArg["project.Project"]}/Networks`,
-        }),
-        providesTags: ["Project"],
-      }),
-      listV1ProjectsProjectProjectNetworks: build.query<
-        ListV1ProjectsProjectProjectNetworksApiResponse,
-        ListV1ProjectsProjectProjectNetworksApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/v1/projects/${queryArg["project.Project"]}/networks`,
-        }),
-        providesTags: ["Network"],
-      }),
-      deleteV1ProjectsProjectProjectNetworksNetworkNetwork: build.mutation<
-        DeleteV1ProjectsProjectProjectNetworksNetworkNetworkApiResponse,
-        DeleteV1ProjectsProjectProjectNetworksNetworkNetworkApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/v1/projects/${queryArg["project.Project"]}/networks/${queryArg["network.Network"]}`,
-          method: "DELETE",
-        }),
-        invalidatesTags: ["Network"],
-      }),
-      getV1ProjectsProjectProjectNetworksNetworkNetwork: build.query<
-        GetV1ProjectsProjectProjectNetworksNetworkNetworkApiResponse,
-        GetV1ProjectsProjectProjectNetworksNetworkNetworkApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/v1/projects/${queryArg["project.Project"]}/networks/${queryArg["network.Network"]}`,
-        }),
-        providesTags: ["Network"],
-      }),
-      putV1ProjectsProjectProjectNetworksNetworkNetwork: build.mutation<
-        PutV1ProjectsProjectProjectNetworksNetworkNetworkApiResponse,
-        PutV1ProjectsProjectProjectNetworksNetworkNetworkApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/v1/projects/${queryArg["project.Project"]}/networks/${queryArg["network.Network"]}`,
-          method: "PUT",
-          body: queryArg.networkNetworkPost,
-          params: { update_if_exists: queryArg.updateIfExists },
-        }),
-        invalidatesTags: ["Network"],
-      }),
-      getV1ProjectsProjectProjectNetworksNetworkNetworkStatus: build.query<
-        GetV1ProjectsProjectProjectNetworksNetworkNetworkStatusApiResponse,
-        GetV1ProjectsProjectProjectNetworksNetworkNetworkStatusApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/v1/projects/${queryArg["project.Project"]}/networks/${queryArg["network.Network"]}/status`,
-        }),
-        providesTags: ["Network"],
-      }),
-      getV1ProjectsProjectProjectStatus: build.query<
-        GetV1ProjectsProjectProjectStatusApiResponse,
-        GetV1ProjectsProjectProjectStatusApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/v1/projects/${queryArg["project.Project"]}/status`,
+          url: `/v1/projects/${queryArg.name}/status`,
+          params: { org: queryArg.org },
         }),
         providesTags: ["Project"],
       }),
@@ -172,251 +107,123 @@ const injectedRtkApi = api
   });
 export { injectedRtkApi as tenancyDataModelApi };
 export type ListV1OrgsApiResponse =
-  /** status 200 Response returned back after getting org.Org objects */ OrgOrgList;
+  /** status 200 List of organizations */ OrgList;
 export type ListV1OrgsApiArg = void;
-export type DeleteV1OrgsOrgOrgApiResponse = unknown;
-export type DeleteV1OrgsOrgOrgApiArg = {
-  /** Name of the org.Org node */
-  "org.Org": string;
+export type GetV1OrgsByNameApiResponse = /** status 200 Organization */ Org;
+export type GetV1OrgsByNameApiArg = {
+  /** Org name */
+  name: string;
 };
-export type GetV1OrgsOrgOrgApiResponse =
-  /** status 200 Response returned back after getting org.Org object */ OrgOrgGet;
-export type GetV1OrgsOrgOrgApiArg = {
-  /** Name of the org.Org node */
-  "org.Org": string;
-};
-export type PutV1OrgsOrgOrgApiResponse = /** status 200 Default response */ {
-  message?: string;
-};
-export type PutV1OrgsOrgOrgApiArg = {
-  /** Name of the org.Org node */
-  "org.Org": string;
-  /** If set to false, disables update of preexisting object. Default value is true */
+export type PutV1OrgsByNameApiResponse =
+  /** status 200 Created or updated organization */ Org;
+export type PutV1OrgsByNameApiArg = {
+  /** Org name */
+  name: string;
+  /** If false, the call fails with 409 when the org already exists. Defaults to true. */
   updateIfExists?: boolean;
-  /** Request used to create org.Org */
-  orgOrgPost: OrgOrgPost;
+  orgWrite: OrgWrite;
 };
-export type GetV1OrgsOrgOrgFoldersApiResponse =
-  /** status 200 Response returned back after getting org.Org objects */ OrgOrgNamedLink;
-export type GetV1OrgsOrgOrgFoldersApiArg = {
-  /** Name of the org.Org node */
-  "org.Org": string;
+export type DeleteV1OrgsByNameApiResponse = /** status 200 OK */ void;
+export type DeleteV1OrgsByNameApiArg = {
+  /** Org name */
+  name: string;
 };
-export type GetV1OrgsOrgOrgStatusApiResponse =
-  /** status 200 Response returned back after getting status subresource of org.Org object */ OrgOrgStatus;
-export type GetV1OrgsOrgOrgStatusApiArg = {
-  /** Name of the org.Org node */
-  "org.Org": string;
+export type GetV1OrgsByNameStatusApiResponse =
+  /** status 200 Organization status */ Org;
+export type GetV1OrgsByNameStatusApiArg = {
+  /** Org name */
+  name: string;
 };
 export type ListV1ProjectsApiResponse =
-  /** status 200 Response returned back after getting project.Project objects */ ProjectProjectList;
-// FIXME this parameter has been manually added,
-export type ListV1ProjectsApiArg = { "member-role"?: boolean };
-export type DeleteV1ProjectsProjectProjectApiResponse = unknown;
-export type DeleteV1ProjectsProjectProjectApiArg = {
-  /** Name of the project.Project node */
-  "project.Project": string;
+  /** status 200 List of projects */ ProjectList;
+export type ListV1ProjectsApiArg = {
+  /** Filter to a single org by name. When omitted, the caller's resolved org scope (from JWT) is used. */
+  org?: string;
 };
-export type GetV1ProjectsProjectProjectApiResponse =
-  /** status 200 Response returned back after getting project.Project object */ ProjectProjectGet;
-export type GetV1ProjectsProjectProjectApiArg = {
-  /** Name of the project.Project node */
-  "project.Project": string;
+export type GetV1ProjectsByNameApiResponse = /** status 200 Project */ Project;
+export type GetV1ProjectsByNameApiArg = {
+  /** Project name */
+  name: string;
+  /** Disambiguate by org when the same project name exists under multiple orgs. */
+  org?: string;
 };
-export type PutV1ProjectsProjectProjectApiResponse =
-  /** status 200 Default response */ {
-    message?: string;
-  };
-export type PutV1ProjectsProjectProjectApiArg = {
-  /** Name of the project.Project node */
-  "project.Project": string;
-  /** If set to false, disables update of preexisting object. Default value is true */
+export type PutV1ProjectsByNameApiResponse =
+  /** status 200 Created or updated project */ Project;
+export type PutV1ProjectsByNameApiArg = {
+  /** Project name */
+  name: string;
+  /** Target org (required for creation when the caller has scope to multiple orgs). */
+  org?: string;
+  /** If false, the call fails with 409 when the project already exists. Defaults to true. */
   updateIfExists?: boolean;
-  /** Request used to create project.Project */
-  projectProjectPost: ProjectProjectPost;
+  projectWrite: ProjectWrite;
 };
-export type GetV1ProjectsProjectProjectNetworksApiResponse =
-  /** status 200 Response returned back after getting project.Project objects */ ProjectProjectNamedLink;
-export type GetV1ProjectsProjectProjectNetworksApiArg = {
-  /** Name of the project.Project node */
-  "project.Project": string;
+export type DeleteV1ProjectsByNameApiResponse = /** status 200 OK */ void;
+export type DeleteV1ProjectsByNameApiArg = {
+  /** Project name */
+  name: string;
+  /** Disambiguate by org when the same project name exists under multiple orgs. */
+  org?: string;
 };
-export type ListV1ProjectsProjectProjectNetworksApiResponse =
-  /** status 200 Response returned back after getting network.Network objects */ NetworkNetworkList;
-export type ListV1ProjectsProjectProjectNetworksApiArg = {
-  /** Name of the project.Project node */
-  "project.Project": string;
+export type GetV1ProjectsByNameStatusApiResponse =
+  /** status 200 Project status */ Project;
+export type GetV1ProjectsByNameStatusApiArg = {
+  /** Project name */
+  name: string;
+  org?: string;
 };
-export type DeleteV1ProjectsProjectProjectNetworksNetworkNetworkApiResponse =
-  unknown;
-export type DeleteV1ProjectsProjectProjectNetworksNetworkNetworkApiArg = {
-  /** Name of the project.Project node */
-  "project.Project": string;
-  /** Name of the network.Network node */
-  "network.Network": string;
-};
-export type GetV1ProjectsProjectProjectNetworksNetworkNetworkApiResponse =
-  /** status 200 Response returned back after getting network.Network object */ NetworkNetworkGet;
-export type GetV1ProjectsProjectProjectNetworksNetworkNetworkApiArg = {
-  /** Name of the project.Project node */
-  "project.Project": string;
-  /** Name of the network.Network node */
-  "network.Network": string;
-};
-export type PutV1ProjectsProjectProjectNetworksNetworkNetworkApiResponse =
-  /** status 200 Default response */ {
-    message?: string;
-  };
-export type PutV1ProjectsProjectProjectNetworksNetworkNetworkApiArg = {
-  /** Name of the project.Project node */
-  "project.Project": string;
-  /** Name of the network.Network node */
-  "network.Network": string;
-  /** If set to false, disables update of preexisting object. Default value is true */
-  updateIfExists?: boolean;
-  /** Request used to create network.Network */
-  networkNetworkPost: NetworkNetworkPost;
-};
-export type GetV1ProjectsProjectProjectNetworksNetworkNetworkStatusApiResponse =
-  /** status 200 Response returned back after getting status subresource of network.Network object */ NetworkNetworkStatus;
-export type GetV1ProjectsProjectProjectNetworksNetworkNetworkStatusApiArg = {
-  /** Name of the project.Project node */
-  "project.Project": string;
-  /** Name of the network.Network node */
-  "network.Network": string;
-};
-export type GetV1ProjectsProjectProjectStatusApiResponse =
-  /** status 200 Response returned back after getting status subresource of project.Project object */ ProjectProjectStatus;
-export type GetV1ProjectsProjectProjectStatusApiArg = {
-  /** Name of the project.Project node */
-  "project.Project": string;
-};
-export type OrgOrgList = {
-  name?: string;
-  spec?: {
-    description?: string;
-  };
-  status?: {
-    orgStatus?: {
-      message?: string;
-      statusIndicator?: string;
-      timeStamp?: number;
-      uID?: string;
-    };
-  };
-}[];
-export type OrgOrgGet = {
-  spec?: {
-    description?: string;
-  };
-  status?: {
-    orgStatus?: {
-      message?: string;
-      statusIndicator?: string;
-      timeStamp?: number;
-      uID?: string;
-    };
-  };
-};
-export type OrgOrgPost = {
+export type OrgSpec = {
   description?: string;
 };
-export type OrgOrgNamedLink = object[];
-export type OrgOrgStatus = {
-  orgStatus?: {
-    message?: string;
-    statusIndicator?: string;
-    timeStamp?: number;
-    uID?: string;
-  };
+export type StatusDetail = {
+  /** One of STATUS_INDICATION_IN_PROGRESS, STATUS_INDICATION_IDLE, STATUS_INDICATION_ERROR. */
+  statusIndicator?: string;
+  message?: string;
+  timeStamp?: number;
+  /** Stable UUID of the resource. */
+  uID?: string;
 };
-export type ProjectProjectList = {
+export type OrgStatusWrap = {
+  orgStatus?: StatusDetail;
+};
+export type Org = {
   name?: string;
-  spec?: {
-    description?: string;
-  };
-  status?: {
-    projectStatus?: {
-      message?: string;
-      statusIndicator?: string;
-      timeStamp?: number;
-      uID?: string;
-    };
-  };
-}[];
-export type ProjectProjectGet = {
-  spec?: {
-    description?: string;
-  };
-  status?: {
-    projectStatus?: {
-      message?: string;
-      statusIndicator?: string;
-      timeStamp?: number;
-      uID?: string;
-    };
-  };
+  spec?: OrgSpec;
+  status?: OrgStatusWrap;
 };
-export type ProjectProjectPost = {
+export type OrgList = Org[];
+export type Error = {
+  error?: string;
+};
+export type OrgWrite = {
   description?: string;
 };
-export type ProjectProjectNamedLink = object[];
-export type NetworkNetworkList = {
-  name?: string;
-  spec?: {
-    description?: string;
-    type?: string;
-  };
-  status?: {
-    status?: {
-      currentState?: string;
-    };
-  };
-}[];
-export type NetworkNetworkGet = {
-  spec?: {
-    description?: string;
-    type?: string;
-  };
-  status?: {
-    status?: {
-      currentState?: string;
-    };
-  };
-};
-export type NetworkNetworkPost = {
+export type ProjectSpec = {
   description?: string;
-  type?: string;
 };
-export type NetworkNetworkStatus = {
-  status?: {
-    currentState?: string;
-  };
+export type ProjectStatusWrap = {
+  projectStatus?: StatusDetail;
 };
-export type ProjectProjectStatus = {
-  projectStatus?: {
-    message?: string;
-    statusIndicator?: string;
-    timeStamp?: number;
-    uID?: string;
-  };
+export type Project = {
+  name?: string;
+  /** Name of the org the project belongs to. */
+  orgName?: string;
+  spec?: ProjectSpec;
+  status?: ProjectStatusWrap;
+};
+export type ProjectList = Project[];
+export type ProjectWrite = {
+  description?: string;
 };
 export const {
   useListV1OrgsQuery,
-  useDeleteV1OrgsOrgOrgMutation,
-  useGetV1OrgsOrgOrgQuery,
-  usePutV1OrgsOrgOrgMutation,
-  useGetV1OrgsOrgOrgFoldersQuery,
-  useGetV1OrgsOrgOrgStatusQuery,
+  useGetV1OrgsByNameQuery,
+  usePutV1OrgsByNameMutation,
+  useDeleteV1OrgsByNameMutation,
+  useGetV1OrgsByNameStatusQuery,
   useListV1ProjectsQuery,
-  useDeleteV1ProjectsProjectProjectMutation,
-  useGetV1ProjectsProjectProjectQuery,
-  usePutV1ProjectsProjectProjectMutation,
-  useGetV1ProjectsProjectProjectNetworksQuery,
-  useListV1ProjectsProjectProjectNetworksQuery,
-  useDeleteV1ProjectsProjectProjectNetworksNetworkNetworkMutation,
-  useGetV1ProjectsProjectProjectNetworksNetworkNetworkQuery,
-  usePutV1ProjectsProjectProjectNetworksNetworkNetworkMutation,
-  useGetV1ProjectsProjectProjectNetworksNetworkNetworkStatusQuery,
-  useGetV1ProjectsProjectProjectStatusQuery,
+  useGetV1ProjectsByNameQuery,
+  usePutV1ProjectsByNameMutation,
+  useDeleteV1ProjectsByNameMutation,
+  useGetV1ProjectsByNameStatusQuery,
 } = injectedRtkApi;

--- a/library/components/atomic-design/organisms/ProjectSwitch/ProjectSwitch.pom.ts
+++ b/library/components/atomic-design/organisms/ProjectSwitch/ProjectSwitch.pom.ts
@@ -26,7 +26,7 @@ type ApiAliases = SuccessApiAliases | ErrrorApiAliases;
 
 const successEndpoints: CyApiDetails<SuccessApiAliases, Project[]> = {
   getProjects: {
-    route: "*/projects?member-role=true",
+    route: "*/projects*",
     statusCode: 200,
     response: [...Array(mockProjectLength).keys()].map((index) => ({
       name: `project-${index}`,
@@ -44,12 +44,12 @@ const successEndpoints: CyApiDetails<SuccessApiAliases, Project[]> = {
     })),
   },
   getProjectsEmpty: {
-    route: "*/projects?member-role=true",
+    route: "*/projects*",
     statusCode: 200,
     response: [],
   },
   getProjectsSampleProject: {
-    route: "*/projects?member-role=true",
+    route: "*/projects*",
     statusCode: 200,
     response: [
       {
@@ -75,7 +75,7 @@ const errorEndpoints: CyApiDetails<
   Partial<InfraUIMessageError>
 > = {
   getProjectsMissingOrg: {
-    route: "*/projects?member-role=true",
+    route: "*/projects*",
     statusCode: 401,
     response: {
       message: "Unauthorized",

--- a/library/components/atomic-design/organisms/ProjectSwitch/ProjectSwitch.tsx
+++ b/library/components/atomic-design/organisms/ProjectSwitch/ProjectSwitch.tsx
@@ -21,7 +21,7 @@ import { SquareSpinner } from "../../atoms/SquareSpinner/SquareSpinner";
 import { RBACWrapper } from "../../molecules/RBACWrapper/RBACWrapper";
 import "./ProjectSwitch.scss";
 
-export type Project = tm.ProjectProjectGet & { name?: string };
+export type Project = tm.Project & { name?: string };
 
 const dataCy = "projectSwitch";
 export interface ProjectSwitchProps {
@@ -88,7 +88,7 @@ export const ProjectSwitch = ({
     isError,
     error,
   } = tm.useListV1ProjectsQuery(
-    { "member-role": true },
+    {},
     {
       // Poll if we are showing projects or if no project is selected
       ...(!showProjects || !selectedProject
@@ -131,7 +131,7 @@ export const ProjectSwitch = ({
 
     if (isError) {
       const err = error as InternalError;
-      // NOTE the /v1/projects?member-role=true returns 401 if the user is not associated with any project
+      // NOTE the /v1/projects endpoint returns 401 if the user is not associated with any project
       if (err?.status === 401) {
         SharedStorage.removeStorageItem(StorageItems.PROJECT);
         navigate(projectHomeLink);

--- a/library/utils/global/admin/global.ts
+++ b/library/utils/global/admin/global.ts
@@ -5,8 +5,8 @@
 
 import { tm } from "@orch-ui/apis";
 
-/** Actual GET Project type. TODO: Update `ProjectProjectGet` to have `name` option */
-export type AdminProject = tm.ProjectProjectGet & { name?: string };
+/** Actual GET Project type. */
+export type AdminProject = tm.Project;
 /** Controller Input format used for react form controller of create,delete & rename project modal */
 export interface ProjectModalInput {
   nameInput: string;

--- a/library/utils/mocks/app-orch/adm/deploymentManager.ts
+++ b/library/utils/mocks/app-orch/adm/deploymentManager.ts
@@ -40,7 +40,7 @@ export const handlers = [
             description: "third network",
           },
         },
-      ] as tm.ListV1ProjectsProjectProjectNetworksApiResponse,
+      ],
       { status: 200 },
     );
   }),

--- a/library/utils/mocks/tenancy/data/organizations.ts
+++ b/library/utils/mocks/tenancy/data/organizations.ts
@@ -5,7 +5,7 @@
 
 import { tm } from "@orch-ui/apis";
 
-export const orgs: tm.OrgOrgList = [
+export const orgs: tm.OrgList = [
   {
     name: "intel",
     spec: {
@@ -23,12 +23,12 @@ export const orgs: tm.OrgOrgList = [
 ];
 
 export default class OrganizationStore {
-  orgs: tm.OrgOrgList;
+  orgs: tm.OrgList;
   constructor() {
     this.orgs = orgs;
   }
 
-  list(): tm.OrgOrgList {
+  list(): tm.OrgList {
     return this.orgs;
   }
 }

--- a/tests/cypress/support/commands.ts
+++ b/tests/cypress/support/commands.ts
@@ -115,7 +115,7 @@ Cypress.Commands.add(
 
 Cypress.Commands.add("currentProject", () => {
   cy.visit("/");
-  cy.intercept("/v1/projects?member-role=true").as("getProjects");
+  cy.intercept("/v1/projects*").as("getProjects");
   cy.url().should("contain", Cypress.config().baseUrl!);
   cy.contains("Dashboard").should("be.visible");
   cy.dataCy("projectSwitchText").should("not.have.text", "Select Projects");


### PR DESCRIPTION
- Add OpenAPI 3.0.3 spec for the new tenancy-manager service (orgs/projects only; networks/folders removed)

- Regenerate library/apis/tenancy/tenancyDataModelApi.ts

- Migrate callers: drop member-role query, rename hooks/types (OrgOrg*/ProjectProject* -> Org/Project), use OrgWrite/ProjectWrite, update cypress intercepts and mocks

# PR Description

Describe the purpose of this pull request.

## Changes

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated