### PR TITLE
Remove trigger on tag from post-merge workflows

### DIFF
--- a/.github/workflows/post-merge-admin.yml
+++ b/.github/workflows/post-merge-admin.yml
@@ -12,8 +12,6 @@ on:
     paths:
       - 'apps/admin/**'
       - 'package-lock.json'
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-app-orch.yml
+++ b/.github/workflows/post-merge-app-orch.yml
@@ -12,8 +12,6 @@ on:
     paths:
       - 'apps/app-orch/**'
       - 'package-lock.json'
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-cluster-orch.yml
+++ b/.github/workflows/post-merge-cluster-orch.yml
@@ -12,8 +12,6 @@ on:
     paths:
       - 'apps/cluster-orch/**'
       - 'package-lock.json'
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-infra.yml
+++ b/.github/workflows/post-merge-infra.yml
@@ -12,8 +12,6 @@ on:
     paths:
       - 'apps/infra/**'
       - 'package-lock.json'
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-root.yml
+++ b/.github/workflows/post-merge-root.yml
@@ -12,8 +12,6 @@ on:
     paths:
       - 'apps/root/**'
       - 'package-lock.json'
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -11,8 +11,6 @@ on:
       - release-*
     paths:
       - 'tests/**'
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow YAML files to remove the workflow trigger on tag creation. Now, these workflows will no longer run when a tag is pushed or created, but will still be triggered by changes to specified paths or by manual dispatch.

**Workflow trigger updates:**

* Removed the `tags` trigger (which matched all tags) from the following workflow files, so they no longer run on tag creation:  
  - `.github/workflows/post-merge-admin.yml`
  - `.github/workflows/post-merge-app-orch.yml`
  - `.github/workflows/post-merge-cluster-orch.yml`
  - `.github/workflows/post-merge-infra.yml`
  - `.github/workflows/post-merge-root.yml`
  - `.github/workflows/post-merge-tests.yml`