### PR TITLE
Added site details drawer in Hosts list view

### DIFF
--- a/apps/infra/src/components/atom/SiteCell/SiteCell.tsx
+++ b/apps/infra/src/components/atom/SiteCell/SiteCell.tsx
@@ -10,7 +10,6 @@ import { Drawer } from "@spark-design/react";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import { selectSite, setSite } from "../../../store/locations";
 import { DrawerHeader } from "../../molecules/DrawerHeader/DrawerHeader";
-import { handleSiteViewAction } from "../../organism/locations/RegionSiteTree/RegionSiteTree.handlers";
 import { SiteView } from "../../organism/locations/SiteView/SiteView";
 const dataCy = "siteCell";
 
@@ -84,7 +83,7 @@ const SiteCell = ({ siteId, regionId = "*" }: SiteCellProps) => {
         role="button"
         tabIndex={0}
         style={{ cursor: "pointer" }}
-        onClick={() => handleSiteViewAction(dispatch, site)}
+        onClick={() => dispatch(setSite(site))}
       >
         {site.name}
       </a>

--- a/apps/infra/src/components/atom/SiteCell/SiteCell.tsx
+++ b/apps/infra/src/components/atom/SiteCell/SiteCell.tsx
@@ -5,9 +5,44 @@
 
 import { infra } from "@orch-ui/apis";
 import { SquareSpinner } from "@orch-ui/components";
-import { getInfraPath, regionSiteRoute, SharedStorage } from "@orch-ui/utils";
-import { Link } from "react-router-dom";
+import { SharedStorage } from "@orch-ui/utils";
+import { Drawer } from "@spark-design/react";
+import { useAppDispatch, useAppSelector } from "../../../store/hooks";
+import { selectSite, setSite } from "../../../store/locations";
+import { DrawerHeader } from "../../molecules/DrawerHeader/DrawerHeader";
+import { handleSiteViewAction } from "../../organism/locations/RegionSiteTree/RegionSiteTree.handlers";
+import { SiteView } from "../../organism/locations/SiteView/SiteView";
 const dataCy = "siteCell";
+
+export interface SiteDetailsDrawerProps {
+  basePath?: string;
+  hideActions?: boolean;
+}
+
+export const SiteDetailsDrawer = ({
+  basePath,
+  hideActions,
+}: SiteDetailsDrawerProps) => {
+  const dispatch = useAppDispatch();
+  const site = useAppSelector(selectSite);
+  return (
+    <Drawer
+      show={site !== undefined}
+      headerProps={{
+        headerContent: site && (
+          <DrawerHeader
+            targetEntity={site}
+            targetEntityType="site"
+            onClose={() => dispatch(setSite(undefined))}
+          />
+        ),
+      }}
+      bodyContent={<SiteView basePath={basePath} hideActions={hideActions} />}
+      backdropClosable
+      onHide={() => dispatch(setSite(undefined))}
+    />
+  );
+};
 
 export interface SiteCellProps {
   siteId?: string;
@@ -16,6 +51,7 @@ export interface SiteCellProps {
 }
 const SiteCell = ({ siteId, regionId = "*" }: SiteCellProps) => {
   const cy = { "data-cy": dataCy };
+  const dispatch = useAppDispatch();
 
   const {
     data: site,
@@ -42,16 +78,18 @@ const SiteCell = ({ siteId, regionId = "*" }: SiteCellProps) => {
     return <span {...cy}>{siteId}</span>;
   }
   return (
-    <Link
-      {...cy}
-      to={getInfraPath(regionSiteRoute, {
-        regionId: site.region?.resourceId ?? "",
-        siteId: siteId,
-      })}
-      relative="path"
-    >
-      {site.name}
-    </Link>
+    <>
+      <a
+        {...cy}
+        role="button"
+        tabIndex={0}
+        style={{ cursor: "pointer" }}
+        onClick={() => handleSiteViewAction(dispatch, site)}
+      >
+        {site.name}
+      </a>
+      <SiteDetailsDrawer />
+    </>
   );
 };
 


### PR DESCRIPTION
# PR Description

Added site details drawer in Hosts list view

## Changes
Attached image shows that the site details drawer is opened in Hosts table:

<img width="1919" height="884" alt="image" src="https://github.com/user-attachments/assets/37044245-c9c5-4140-b098-e1723062023e" />

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated