### PR TITLE
Hiding the host actions option from site details drawer

### DIFF
--- a/apps/infra/src/components/molecules/locations/SiteViewHostTable/SiteViewHostTable.tsx
+++ b/apps/infra/src/components/molecules/locations/SiteViewHostTable/SiteViewHostTable.tsx
@@ -14,20 +14,27 @@ const dataCy = "siteViewHostTable";
 export interface SiteViewHostTableProps {
   site?: infra.SiteResourceRead;
   basePath?: string;
+  hideActions?: boolean;
 }
 export const SiteViewHostTable = ({
   site,
   basePath,
+  hideActions = false,
 }: SiteViewHostTableProps) => {
   const cy = { "data-cy": dataCy };
 
   const columns: TableColumn<infra.HostResourceRead>[] = [
     HostTableColumn.name(),
     HostTableColumn.status,
-    HostTableColumn.actions((host: infra.HostResourceRead) => (
-      <HostPopup host={host} basePath={basePath} />
-    )),
-  ];
+  ].filter(Boolean);
+
+  if (!hideActions) {
+    columns.push(
+      HostTableColumn.actions((host: infra.HostResourceRead) => (
+        <HostPopup host={host} basePath={basePath} />
+      )),
+    );
+  }
 
   const projectName = SharedStorage.project?.name ?? "";
   const { data, isSuccess, isError, isLoading, error } =

--- a/apps/infra/src/components/organism/locations/SiteView/SiteView.tsx
+++ b/apps/infra/src/components/organism/locations/SiteView/SiteView.tsx
@@ -76,7 +76,7 @@ export const SiteView = ({ basePath, hideActions = false }: SiteViewProps) => {
       <Heading semanticLevel={5} className={`${className}__hosts`}>
         Hosts
       </Heading>
-      <SiteViewHostTable site={site} basePath={basePath} />
+      <SiteViewHostTable site={site} basePath={basePath} hideActions />
     </div>
   );
 };


### PR DESCRIPTION
# PR Description

Host operations should be performed from the dedicated Host page rather than the Site details drawer. The Site details drawer displays hosts for reference purposes only and maintains read-only functionality. Accordingly, host actions have been removed from the Site details drawer to ensure users access the appropriate operational interface.

## Changes

<img width="1310" height="776" alt="image" src="https://github.com/user-attachments/assets/1e93f77c-3edc-4d9d-ba42-e5135c8ec1f5" />


## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated