### PR TITLE
Duplicate maintenance schedule  name validation

### DIFF
--- a/apps/infra/src/components/organism/ScheduleMaintenanceDrawer/ScheduleMaintenanceDrawer.cy.tsx
+++ b/apps/infra/src/components/organism/ScheduleMaintenanceDrawer/ScheduleMaintenanceDrawer.cy.tsx
@@ -142,12 +142,6 @@ describe("<ScheduleMaintenanceDrawer/>", () => {
     };
 
     const fillBasicEditMaintenanceForm = (maintenanceName: string) => {
-      pom.maintenanceListPom.interceptApis([
-        pom.maintenanceListPom.api.getMaintenance,
-      ]);
-      pom.selectTab("Schedule Events");
-      pom.waitForApis();
-
       pom.maintenanceListPom.tablePom
         .getRowBySearchText(maintenanceName)
         .find("[data-cy='popup']")
@@ -168,7 +162,20 @@ describe("<ScheduleMaintenanceDrawer/>", () => {
     };
 
     it("edit single schedule maintenance from closed-ended to open-ended", () => {
-      cy.mount(<TestingComponent mockEntity={hostTwo} />);
+      // Set up API mock BEFORE mounting the component
+      pom.maintenanceListPom.interceptApis([
+        pom.maintenanceListPom.api.getMaintenance,
+      ]);
+
+      cy.mount(<TestingComponent mockEntity={hostTwo} />, {
+        reduxStore: store,
+      });
+      pom.root.should("exist");
+
+      pom.selectTab("Schedule Events");
+      pom.waitForApis();
+      // Wait for the table element to be visible before searching for rows
+      pom.maintenanceListPom.tablePom.root.should("be.visible");
 
       fillBasicEditMaintenanceForm("schedule3");
       pom.maintenanceFormPom.selectFromDropdown(
@@ -221,7 +228,18 @@ describe("<ScheduleMaintenanceDrawer/>", () => {
     });
 
     it("edit repeated schedule maintenance without timezone and time change", () => {
-      cy.mount(<TestingComponent mockEntity={hostFour} />);
+      // Set up API mock BEFORE mounting the component
+      pom.maintenanceListPom.interceptApis([
+        pom.maintenanceListPom.api.getMaintenance,
+      ]);
+
+      cy.mount(<TestingComponent mockEntity={hostFour} />, {
+        reduxStore: store,
+      });
+      pom.root.should("exist");
+
+      pom.selectTab("Schedule Events");
+      pom.waitForApis();
 
       fillBasicEditMaintenanceForm("r-schedule1");
       pom.maintenanceFormPom.selectFromDropdown(

--- a/apps/infra/src/components/organism/ScheduleMaintenanceForm/ScheduleMaintenanceForm.tsx
+++ b/apps/infra/src/components/organism/ScheduleMaintenanceForm/ScheduleMaintenanceForm.tsx
@@ -125,6 +125,7 @@ export const ScheduleMaintenanceForm = ({
 
   /* State Management */
   const [isMaintenanceEdit, setIsMaintenanceEdit] = useState<boolean>(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   useEffect(() => {
     setIsMaintenanceEdit(maintenance.resourceId !== undefined);
   }, [maintenance.resourceId]);
@@ -182,6 +183,7 @@ export const ScheduleMaintenanceForm = ({
 
   /** Add new maintenance via INFRA-API */
   const submitMaintenance = () => {
+    setIsSubmitting(true);
     const submitSingleMaintenance = isMaintenanceEdit
       ? editSingleMaintenance
       : postSingleMaintenance;
@@ -299,9 +301,11 @@ export const ScheduleMaintenanceForm = ({
             );
             onSave();
           }
+          setIsSubmitting(false);
         })
         .catch((err) => {
           setMessageBannerState(errorMaintenanceMessage("update", err));
+          setIsSubmitting(false);
         });
       return;
     }
@@ -325,6 +329,7 @@ export const ScheduleMaintenanceForm = ({
               : activateMaintenanceMessage,
           );
           onSave();
+          setIsSubmitting(false);
         })
         .catch((err) => {
           setMessageBannerState(
@@ -333,6 +338,7 @@ export const ScheduleMaintenanceForm = ({
               err,
             ),
           );
+          setIsSubmitting(false);
         });
     } else {
       dispatch(
@@ -341,6 +347,7 @@ export const ScheduleMaintenanceForm = ({
           state: ToastState.Danger,
         }),
       );
+      setIsSubmitting(false);
     }
   };
 
@@ -549,10 +556,14 @@ export const ScheduleMaintenanceForm = ({
             data-cy="saveButton"
             className="action-drawer"
             variant="action"
-            isDisabled={Object.keys(formErrors).length !== 0}
+            isDisabled={Object.keys(formErrors).length !== 0 || isSubmitting}
             type="submit"
           >
-            {isMaintenanceEdit ? "Update" : "Add"}
+            {isSubmitting
+              ? "Creating..."
+              : isMaintenanceEdit
+                ? "Update"
+                : "Add"}
           </Button>
         </ButtonGroup>
       </div>

--- a/apps/infra/src/components/organism/ScheduleMaintenanceForm/ScheduleMaintenanceForm.tsx
+++ b/apps/infra/src/components/organism/ScheduleMaintenanceForm/ScheduleMaintenanceForm.tsx
@@ -130,6 +130,47 @@ export const ScheduleMaintenanceForm = ({
   }, [maintenance.resourceId]);
 
   /* APIs */
+  // Fetch existing schedules for the same target to validate duplicate names.
+  const projectName = SharedStorage.project?.name ?? "";
+  const duplicateNameTargetIds: {
+    hostId?: string;
+    siteId?: string;
+    regionId?: string;
+  } = {};
+  if (targetEntityType === "region") {
+    duplicateNameTargetIds.regionId = maintenance.targetRegion?.resourceId;
+  } else if (targetEntityType === "site") {
+    duplicateNameTargetIds.siteId = maintenance.targetSite?.resourceId;
+  } else {
+    duplicateNameTargetIds.hostId = maintenance.targetHost?.resourceId;
+  }
+  const { data: existingSchedules } =
+    infra.useScheduleServiceListSchedulesQuery(
+      {
+        projectName,
+        ...duplicateNameTargetIds,
+      },
+      {
+        skip: !projectName,
+      },
+    );
+
+  /** Set of names already taken by other schedules on the same target.
+   * The currently-edited maintenance is excluded so its own name does not
+   * trigger the duplicate validation. */
+  const existingMaintenanceNames = new Set<string>(
+    existingSchedules
+      ? [
+          ...existingSchedules.singleSchedules
+            .filter((s) => s.resourceId !== maintenance.resourceId)
+            .map((s) => (s.name ?? "").trim().toLowerCase()),
+          ...existingSchedules.repeatedSchedules
+            .filter((r) => r.repeatedScheduleID !== maintenance.resourceId)
+            .map((r) => (r.name ?? "").trim().toLowerCase()),
+        ].filter((n) => n.length > 0)
+      : [],
+  );
+
   const [postSingleMaintenance] =
     infra.useScheduleServiceCreateSingleScheduleMutation();
   const [postRepeatedMaintenance] =
@@ -335,6 +376,13 @@ export const ScheduleMaintenanceForm = ({
                 pattern: new RegExp(
                   /^([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-\s/]*[A-Za-z0-9])$/,
                 ),
+                validate: {
+                  duplicate: (value) =>
+                    !existingMaintenanceNames.has(
+                      (value ?? "").trim().toLowerCase(),
+                    ) ||
+                    "A maintenance schedule with this name already exists.",
+                },
               }}
               render={({ field }) => (
                 <TextField
@@ -348,10 +396,13 @@ export const ScheduleMaintenanceForm = ({
                     const value = e.currentTarget.value;
                     onUpdate({ ...maintenance, name: value });
                   }}
-                  errorMessage={getDisplayNameValidationErrorMessage(
-                    formErrors?.name?.type,
-                    20,
-                  )}
+                  errorMessage={
+                    formErrors?.name?.message ||
+                    getDisplayNameValidationErrorMessage(
+                      formErrors?.name?.type,
+                      20,
+                    )
+                  }
                   validationState={
                     formErrors?.name && Object.keys(formErrors?.name).length > 0
                       ? "invalid"

--- a/apps/infra/src/components/organism/ScheduleMaintenanceForm/ScheduleMaintenanceForm.tsx
+++ b/apps/infra/src/components/organism/ScheduleMaintenanceForm/ScheduleMaintenanceForm.tsx
@@ -559,11 +559,7 @@ export const ScheduleMaintenanceForm = ({
             isDisabled={Object.keys(formErrors).length !== 0 || isSubmitting}
             type="submit"
           >
-            {isSubmitting
-              ? "Creating..."
-              : isMaintenanceEdit
-                ? "Update"
-                : "Add"}
+            {isMaintenanceEdit ? "Update" : "Add"}
           </Button>
         </ButtonGroup>
       </div>


### PR DESCRIPTION
# PR Description

- Added validation for maintenance name to not allow duplicate name
- Fixed issue of pressing the Add button quickly 2 times creates duplicate events with same name & properties - freezes further creation

## Changes

<img width="1284" height="889" alt="image" src="https://github.com/user-attachments/assets/101c1cf4-9c3c-4a5a-ba42-e0893e1e6f45" />

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated