### PR TITLE
Fix: Remove deleted locations from UI without page refresh

### DIFF
--- a/apps/infra/src/components/pages/Locations/Locations.tsx
+++ b/apps/infra/src/components/pages/Locations/Locations.tsx
@@ -112,7 +112,7 @@ export const Locations = () => {
             variant: MessageBannerAlertState.Success,
           }),
         );
-        if (regionToDelete) dispatch(deleteTreeNode());
+        dispatch(deleteTreeNode(regionId));
       })
       .catch((error) => {
         dispatch(

--- a/apps/infra/src/store/locations.ts
+++ b/apps/infra/src/store/locations.ts
@@ -103,15 +103,15 @@ export const locations = createSlice({
       state.regionId = undefined;
       state.regionToDelete = action.payload;
     },
-    deleteTreeNode(state: LocationsState) {
-      if (!state.regionToDelete) return;
-      const { regionToDelete } = state;
+    deleteTreeNode(
+      state: LocationsState,
+      action: PayloadAction<string | undefined>,
+    ) {
+      const resourceId = action.payload ?? state.regionToDelete?.resourceId;
+      if (!resourceId) return;
 
       //first check if its a root node
-      const node = TreeBranchStateUtils.find(
-        regionToDelete.resourceId!,
-        state.branches,
-      );
+      const node = TreeBranchStateUtils.find(resourceId, state.branches);
       if (node?.isRoot) {
         const rootIndex = state.branches.findIndex(
           (root) => root.id === node.id,
@@ -122,14 +122,14 @@ export const locations = createSlice({
       }
 
       const parent = TreeBranchStateUtils.find(
-        regionToDelete.resourceId!,
+        resourceId,
         state.branches,
         true,
       );
       if (!parent || !parent.children) return;
       const { children } = parent;
       const index = children.findIndex((child) => {
-        return child.id === regionToDelete.resourceId;
+        return child.id === resourceId;
       });
 
       children.splice(index, 1);


### PR DESCRIPTION
# PR Description

Remove deleted location from UI without requiring manual refresh Resolved an issue where deleted locations remained visible in the user interface until the page was manually refreshed. The UI now properly updates in real-time when a location is deleted.

## Changes

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated